### PR TITLE
Add peek-experiments: hands-on exploration of the PEEK orientation cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ While this is primarily a coding agent workspace, contributions and suggestions 
 |-----------|-------------|
 | [`vulnllm-analyzer/`](vulnllm-analyzer/) | Automated vulnerability analysis for GitHub repos using [VulnLLM-R-7B](https://github.com/ucsb-mlsec/VulnLLM-R) on Modal GPUs |
 | [recursive-lm-security-audit](./recursive-lm-security-audit/) | Automated codebase security scanner using DSPy's Recursive Language Model (RLM) module. Accepts a GitHub repo URL or local path and produces a vulnerability report for ~$0.87. |
+| [`peek-experiments/`](peek-experiments/) | Hands-on exploration of [PEEK](https://github.com/zhuohangu/peek), an orientation cache for long-context LLM agents. Runs PEEK's real `CachePolicy` loop end to end with an offline scripted LM client. |
 
 ## Note
 

--- a/peek-experiments/.gitignore
+++ b/peek-experiments/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+output/

--- a/peek-experiments/README.md
+++ b/peek-experiments/README.md
@@ -64,8 +64,16 @@ extraction, `ContextMap.apply`, scoring, the Evictor, the freeze, `save`/`load`.
 |------|--------------|
 | `scripted_client.py` | The offline `LMClient` stub + small helpers (`map_ids`, `id_of`, `tags_for`). |
 | `claude_code_client.py` | A live `LMClient` that shells out to the `claude` CLI. Run it directly for a one-call self-test. |
+| `corpus.py` | Generates a deterministic ~72k-char synthetic "ACME handbook" — the real long context experiment 3 navigates. |
+| `rlm_agent.py` | A real RLM agent: answers a question by running code in a persistent Python REPL over a long context until it emits `FINAL:`. |
 | `experiment_1_mechanics.py` | The **deterministic layer**, no LLM: `ContextMap` ADD/REPLACE/DELETE, stable IDs, the scoring convention, and a narrated priority-eviction run. |
-| `experiment_2_policy_loop.py` | The **full `CachePolicy` loop**: an RLM agent answers 5 questions about a fictional ~41k-char employee handbook; the map bootstraps from empty, self-corrects, hits the budget, then freezes. Runs against either backend. |
+| `experiment_2_policy_loop.py` | The **`CachePolicy` loop** over *canned* trajectories: the map bootstraps from empty, self-corrects, hits the budget, then freezes. Runs against either backend. |
+| `experiment_3_rlm.py` | **End to end**: a real RLM agent explores a real corpus; PEEK distills its genuine trajectories. Measures model turns per question, baseline vs PEEK. |
+
+The three experiments form a ladder: #1 is the deterministic core with no model,
+#2 adds the real `CachePolicy` loop but with scripted/curated trajectories, and
+#3 removes the last piece of scaffolding — the trajectories are produced by an
+actual agent doing actual work, so it can *measure* whether the cache helps.
 
 ## Run it
 
@@ -78,6 +86,9 @@ python experiment_1_mechanics.py          # deterministic layer, no LLM
 python experiment_2_policy_loop.py        # offline scripted LM (default, instant)
 python experiment_2_policy_loop.py --live # real LM via the `claude` CLI
 python experiment_2_policy_loop.py --live --model opus   # pick the model
+
+python experiment_3_rlm.py                # end to end: real agent + real corpus (live, slow)
+python experiment_3_rlm.py --questions 2  # shorter / cheaper run
 
 python claude_code_client.py              # one-call self-test of the live client
 

--- a/peek-experiments/README.md
+++ b/peek-experiments/README.md
@@ -1,0 +1,119 @@
+# peek-experiments
+
+Hands-on exploration of **PEEK** — [github.com/zhuohangu/peek](https://github.com/zhuohangu/peek),
+the reference implementation of *"PEEK: Context Map as an Orientation Cache for
+Long-Context LLM Agents"* ([arXiv:2510.04618](https://arxiv.org/abs/2510.04618)).
+
+The goal here is to *understand how PEEK works* by running its real control
+flow end to end and watching the data structures evolve — not to ship anything.
+
+## What PEEK is
+
+When an LLM agent operates repeatedly on the same large external context (a
+document corpus, a code repo), it keeps re-doing the same orientation work:
+figuring out the structure, where things live, what the key entities are.
+
+PEEK caches that **orientation knowledge** as a small, prompt-resident
+**context map** — think "a CPU cache / database index for a long context".
+You prepend the map to the agent's next call so it can skip the rediscovery.
+PEEK is agent-agnostic, model-agnostic, and unsupervised: it learns purely
+from inference-time signals, no ground-truth labels.
+
+## How it works (the parts)
+
+PEEK splits into a deterministic layer and an LM-driven layer.
+
+| Component | Role |
+|-----------|------|
+| **`ContextMap`** | The cache itself: section-indexed text. Each item is one line `[<slug>-NNNNN] content` under a `## SECTION` heading. IDs are stable across edits. Six sections: `context_roadmap`, `context_understanding`, `domain_constants`, `parsing_schema`, `error_patterns`, `reusable_results`. |
+| **`Distiller`** *(LM)* | Reads an agent's run trajectory. Emits a diagnosis, **tags** every existing map item (`helpful` / `harmful` / `neutral` / `stale`), and proposes cache candidates. |
+| **`Cartographer`** *(LM)* | Turns the Distiller's reflection into structured **`ADD` / `DELETE` / `REPLACE`** edits against the map, respecting a token budget. |
+| **`Evictor`** | Deterministic. When the map exceeds its hard token budget, removes items in ascending **(score, age)** order until it fits. `helpful` = +1, `harmful`/`stale` = −1, `neutral` = 0. |
+| **`CachePolicy`** | Orchestrates one update step (PEEK's Algorithm 1): Distiller → score update → Cartographer → apply edits → evict. Freezes the map after `evolve_steps`. `save()` / `load()` persist it. |
+| **`LMClient`** | Minimal protocol — `completion(messages)` + `last_usage()`. Ships with OpenAI / Anthropic / Gemini clients; any stub that satisfies the protocol works. |
+
+The intended loop (from PEEK's own README):
+
+```python
+policy = CachePolicy(client=..., token_budget=1024, evolve_steps=10)
+for question in stream_of_questions:
+    system_prompt = f"{base_instructions}\n\nContext Map:\n{policy.current_map_text}"
+    trajectory = my_agent.run(system_prompt, question, long_external_context)
+    policy.update(trajectory=trajectory, question=question)
+policy.save("maps/my-corpus.peek.json")
+```
+
+## The experiments
+
+PEEK needs an LLM for the Distiller and Cartographer, and this sandbox has no
+API key. So `scripted_client.py` provides a **`ScriptedLMClient`** — a stub
+that satisfies `LMClient` and replays pre-programmed Distiller/Cartographer
+JSON. PEEK's README explicitly endorses "a local stub" as a valid client.
+Everything *except* the model is the genuine PEEK code: JSON extraction,
+`ContextMap.apply`, scoring, the Evictor, the freeze, `save`/`load`.
+
+| File | What it does |
+|------|--------------|
+| `scripted_client.py` | The offline `LMClient` stub + small helpers (`map_ids`, `id_of`, `tags_for`). |
+| `experiment_1_mechanics.py` | The **deterministic layer**, no LLM: `ContextMap` ADD/REPLACE/DELETE, stable IDs, the scoring convention, and a narrated priority-eviction run. |
+| `experiment_2_policy_loop.py` | The **full `CachePolicy` loop** driven by the scripted LM: an RLM agent answers 5 questions about a fictional ~41k-char employee handbook; the map bootstraps from empty, self-corrects, hits the budget, then freezes. |
+
+## Run it
+
+```bash
+pip install -r requirements.txt          # installs peek-ai from GitHub + tiktoken
+cd peek-experiments
+python experiment_1_mechanics.py
+python experiment_2_policy_loop.py        # writes output/acme-handbook.peek.json
+
+# (optional) PEEK's own test suite — 10 tests, all green
+pip install peek-ai[test] && pytest --pyargs peek   # or: pytest tests/ in a peek checkout
+```
+
+## What the experiments show
+
+Experiment 2 walks a context map through its whole life cycle:
+
+```
+STEP 1  bootstrap     map empty -> Cartographer ADDs 3 roadmap items   (104 -> 214 tok)
+STEP 2  accumulate    items tagged helpful; +understanding +PTO table  (214 -> 292 tok)
+STEP 3  self-correct  a roadmap pointer is tagged 'harmful' and DELETEd (292 -> 377 tok)
+STEP 4  budget squeeze 4 ADDs overflow 440 tok -> Evictor removes 2     (-> 432/440 tok)
+STEP 5  frozen        evolve_steps reached -> update() returns None, 0 LM calls
+```
+
+Three behaviours worth calling out:
+
+1. **The map self-corrects.** In step 3 a roadmap item that pointed the agent
+   to the wrong chapter is tagged `harmful` by the Distiller and removed by the
+   Cartographer — bad cache entries don't survive contact with a trajectory
+   that exposes them.
+
+2. **Eviction is score-driven and section-agnostic.** In step 4 the two items
+   evicted are `dc-00005` and `dc-00007` — the *domain constants* (the PTO
+   table and the stipend figure) the loop had carefully cached. They were
+   evicted first because no question ever exercised them, so the Distiller
+   only ever tagged them `neutral` (score 0), while roadmap/parsing items that
+   got used accrued `helpful` (+1…+3). The Evictor looks **only** at the score
+   and item age — never at which section an item is in. The Cartographer
+   *prompt* says "protect domain constants most", but that guidance only
+   steers the Cartographer's own `DELETE` choices; it does not bind the
+   Evictor. Takeaway: under budget pressure, what protects an item is the
+   Distiller repeatedly tagging it `helpful`, not its perceived value.
+
+3. **Evolution is bounded.** With `evolve_steps=4`, the 5th `update()` returns
+   `None` immediately and makes zero LM calls — the map is now a frozen,
+   read-only cache. `save()`/`load()` round-trips it (map text + scores +
+   step count) so it can be reused across processes.
+
+See the script output for the full per-step trace and the final context map.
+
+## Notes
+
+- PEEK's Distiller prompt is written for **RLM** (Recursive Language Model)
+  agents — controller-style agents that explore long context via a REPL — but
+  the `CachePolicy` API itself only ever sees a `trajectory` string, so it is
+  not actually tied to that agent shape.
+- `peek-ai` is not on PyPI yet; `requirements.txt` installs it from the Git
+  repo. The package is small (core depends only on `tiktoken`).
+- `output/` is git-ignored — it only holds the regenerated saved map.

--- a/peek-experiments/README.md
+++ b/peek-experiments/README.md
@@ -172,6 +172,55 @@ but the exact items, tags, and token counts differ run to run, and a real
 Cartographer tends to keep the map compact enough that the Evictor never
 triggers.
 
+## Experiment 3 — does the cache actually pay off?
+
+Experiment 3 is the honest test: a real agent, a real 72k-char corpus, real
+trajectories. One representative run (4 questions, `claude` CLI default model):
+
+```
+#  question                     BASELINE   PEEK     map items
+1  parental leave (weeks)          3 ok     3 ok      0 -> 3
+2  vacation days at 5 yrs          3 ok     6 ok      3 -> 4
+3  home-office setup stipend       3 ok     2 ok      4 -> 5
+4  paid company holidays           3 ok     2 ok      5 -> 6
+   TOTAL model turns              12       13
+```
+
+All 8 answers were correct. The headline is *not* a clean win — PEEK spent 13
+turns to the baseline's 12. But the per-question shape is the real story, and
+it matches PEEK's theory closely:
+
+- **Q1 — tie.** The map starts empty, so the first question can't benefit. Its
+  trajectory is what *seeds* the map.
+- **Q2 — PEEK loses (6 vs 3).** After Q1 the map is only half-built: it had
+  distilled a pointer to the §1.2 "How to Use This Handbook" section — which is
+  exactly the *decoy* table-of-contents. With an immature map quoting a decoy,
+  the agent chased the phrase "vacation accrual" and wandered. **An immature
+  cache can mislead.**
+- **Q3, Q4 — PEEK wins (2 vs 3 each).** By now the Cartographer has distilled a
+  full section-by-section char-offset index. On Q4 the agent's first line of
+  code is literally `i = 40333` — the exact offset of §6.1 lifted straight from
+  the map — and it answers in 2 turns instead of 3.
+
+Takeaways from the real run:
+
+1. **The cache has to mature before it helps.** Empty (Q1) → misleading (Q2) →
+   genuinely useful (Q3–Q4). PEEK's benefit is back-loaded; a 4-question run
+   barely reaches the payoff zone. The win compounds over a longer stream
+   against the now-mature, frozen map.
+2. **PEEK's value scales with orientation cost.** Here the baseline is already
+   fast — a competent agent greps this corpus in 3 turns flat — so there is
+   little rediscovery to amortise. PEEK helps most when orientation is genuinely
+   expensive (deeper structure, weaker search, costlier tools).
+3. **The final map is excellent even though the run netted even.** It ends with
+   a complete offset index and every exact fact (see the script's printed
+   FINAL CONTEXT MAP). The artefact is real and reusable; the 4-question budget
+   just wasn't long enough to cash it in.
+
+So: the full loop works end to end and the measurement is honest — PEEK neither
+magically wins nor fails here; it pays off precisely when and where its design
+predicts, and a short run on an easy corpus lands near break-even.
+
 ## Notes
 
 - PEEK's Distiller prompt is written for **RLM** (Recursive Language Model)

--- a/peek-experiments/README.md
+++ b/peek-experiments/README.md
@@ -45,34 +45,80 @@ policy.save("maps/my-corpus.peek.json")
 
 ## The experiments
 
-PEEK needs an LLM for the Distiller and Cartographer, and this sandbox has no
-API key. So `scripted_client.py` provides a **`ScriptedLMClient`** — a stub
-that satisfies `LMClient` and replays pre-programmed Distiller/Cartographer
-JSON. PEEK's README explicitly endorses "a local stub" as a valid client.
-Everything *except* the model is the genuine PEEK code: JSON extraction,
-`ContextMap.apply`, scoring, the Evictor, the freeze, `save`/`load`.
+PEEK needs an LLM behind the `LMClient` protocol for the Distiller and
+Cartographer. This directory provides **two** ways to satisfy it, neither of
+which needs a PEEK-managed API key:
+
+- **`ScriptedLMClient`** (`scripted_client.py`) — an offline stub that replays
+  pre-programmed Distiller/Cartographer JSON. Deterministic; the run is the
+  same every time. PEEK's README explicitly endorses "a local stub".
+- **`ClaudeCodeClient`** (`claude_code_client.py`) — routes each completion
+  through the local **`claude` CLI** (Claude Code) in non-interactive print
+  mode. A real model does the distilling and cartography; no API key of its
+  own — it reuses whatever auth the Claude Code install already has.
+
+Either way, everything *except* the model is the genuine PEEK code: JSON
+extraction, `ContextMap.apply`, scoring, the Evictor, the freeze, `save`/`load`.
 
 | File | What it does |
 |------|--------------|
 | `scripted_client.py` | The offline `LMClient` stub + small helpers (`map_ids`, `id_of`, `tags_for`). |
+| `claude_code_client.py` | A live `LMClient` that shells out to the `claude` CLI. Run it directly for a one-call self-test. |
 | `experiment_1_mechanics.py` | The **deterministic layer**, no LLM: `ContextMap` ADD/REPLACE/DELETE, stable IDs, the scoring convention, and a narrated priority-eviction run. |
-| `experiment_2_policy_loop.py` | The **full `CachePolicy` loop** driven by the scripted LM: an RLM agent answers 5 questions about a fictional ~41k-char employee handbook; the map bootstraps from empty, self-corrects, hits the budget, then freezes. |
+| `experiment_2_policy_loop.py` | The **full `CachePolicy` loop**: an RLM agent answers 5 questions about a fictional ~41k-char employee handbook; the map bootstraps from empty, self-corrects, hits the budget, then freezes. Runs against either backend. |
 
 ## Run it
 
 ```bash
 pip install -r requirements.txt          # installs peek-ai from GitHub + tiktoken
 cd peek-experiments
-python experiment_1_mechanics.py
-python experiment_2_policy_loop.py        # writes output/acme-handbook.peek.json
+
+python experiment_1_mechanics.py          # deterministic layer, no LLM
+
+python experiment_2_policy_loop.py        # offline scripted LM (default, instant)
+python experiment_2_policy_loop.py --live # real LM via the `claude` CLI
+python experiment_2_policy_loop.py --live --model opus   # pick the model
+
+python claude_code_client.py              # one-call self-test of the live client
 
 # (optional) PEEK's own test suite — 10 tests, all green
 pip install peek-ai[test] && pytest --pyargs peek   # or: pytest tests/ in a peek checkout
 ```
 
+### Live mode — using this Claude Code instance as the LLM
+
+`ClaudeCodeClient` makes PEEK run with no API key by treating the local
+`claude` binary as the model endpoint. Each `completion()` call runs:
+
+```
+claude -p --output-format json --tools "" --no-session-persistence \
+       --strict-mcp-config --system-prompt "<minimal>"
+```
+
+feeding the prompt on stdin and reading the `result` + `usage` fields back out
+of the JSON envelope. Built-in tools are disabled and the coding-agent system
+prompt is replaced, so the call behaves as a plain text completion.
+
+Two practical wrinkles the client handles:
+
+- **It runs the subprocess from an empty, non-git temp directory.** Project
+  `CLAUDE.md`, settings, and *Stop hooks* are discovered from the cwd; the web
+  harness's "uncommitted work" Stop hook would otherwise fire and overwrite the
+  completion with git advice.
+- **It does not use `--bare`.** `--bare` skips hooks (which would also fix the
+  above) but forces API-key auth — broken in environments that authenticate
+  another way. Running from a neutral cwd isolates hooks without touching auth.
+
+`--live` runs are real: ~8 model calls per run, non-deterministic, and they
+cost tokens. The map that emerges will differ from the scripted narrative
+below — e.g. a real Cartographer tends to favour compact `REPLACE`s and may
+never hit the token budget.
+
 ## What the experiments show
 
-Experiment 2 walks a context map through its whole life cycle:
+Experiment 2 (default **scripted** backend) walks a context map through its
+whole life cycle — the scripted run is deterministic, so these numbers are
+exact every time:
 
 ```
 STEP 1  bootstrap     map empty -> Cartographer ADDs 3 roadmap items   (104 -> 214 tok)
@@ -108,6 +154,13 @@ Three behaviours worth calling out:
 
 See the script output for the full per-step trace and the final context map.
 
+Running the same experiment with `--live` confirms the loop behaves the same
+way with a real model in the seat: the map still bootstraps from empty,
+self-corrects the misleading Ch.9 pointer, and freezes after `evolve_steps` —
+but the exact items, tags, and token counts differ run to run, and a real
+Cartographer tends to keep the map compact enough that the Evictor never
+triggers.
+
 ## Notes
 
 - PEEK's Distiller prompt is written for **RLM** (Recursive Language Model)
@@ -116,4 +169,6 @@ See the script output for the full per-step trace and the final context map.
   not actually tied to that agent shape.
 - `peek-ai` is not on PyPI yet; `requirements.txt` installs it from the Git
   repo. The package is small (core depends only on `tiktoken`).
+- `--live` mode needs the `claude` CLI on `PATH` (it is, inside Claude Code on
+  the web). It is unrelated to the `peek-ai` install and needs no extra deps.
 - `output/` is git-ignored — it only holds the regenerated saved map.

--- a/peek-experiments/README.md
+++ b/peek-experiments/README.md
@@ -64,7 +64,7 @@ extraction, `ContextMap.apply`, scoring, the Evictor, the freeze, `save`/`load`.
 |------|--------------|
 | `scripted_client.py` | The offline `LMClient` stub + small helpers (`map_ids`, `id_of`, `tags_for`). |
 | `claude_code_client.py` | A live `LMClient` that shells out to the `claude` CLI. Run it directly for a one-call self-test. |
-| `corpus.py` | Generates a deterministic ~72k-char synthetic "ACME handbook" — the real long context experiment 3 navigates. |
+| `corpus.py` | Generates a deterministic ~116k-char synthetic "ACME handbook" — the long context experiment 3 navigates. Built *orientation-hostile*: function-named chapters and keyword decoys, so finding a fact costs real navigation. |
 | `rlm_agent.py` | A real RLM agent: answers a question by running code in a persistent Python REPL over a long context until it emits `FINAL:`. |
 | `experiment_1_mechanics.py` | The **deterministic layer**, no LLM: `ContextMap` ADD/REPLACE/DELETE, stable IDs, the scoring convention, and a narrated priority-eviction run. |
 | `experiment_2_policy_loop.py` | The **`CachePolicy` loop** over *canned* trajectories: the map bootstraps from empty, self-corrects, hits the budget, then freezes. Runs against either backend. |
@@ -87,9 +87,9 @@ python experiment_2_policy_loop.py        # offline scripted LM (default, instan
 python experiment_2_policy_loop.py --live # real LM via the `claude` CLI
 python experiment_2_policy_loop.py --live --model opus   # pick the model
 
-python experiment_3_rlm.py                # end to end: 3 runs, real agent + corpus (live, slow)
+python experiment_3_rlm.py                # end to end: 3 runs x 8 questions, real agent (live, slow)
 python experiment_3_rlm.py --runs 5       # more runs = tighter estimate
-python experiment_3_rlm.py --runs 1 --questions 2   # quick smoke check
+python experiment_3_rlm.py --runs 1 --questions 3   # quick smoke check
 
 python claude_code_client.py              # one-call self-test of the live client
 
@@ -175,11 +175,11 @@ triggers.
 
 ## Experiment 3 — does the cache measurably pay off?
 
-Experiment 3 is the honest test: a real agent, a real 72k-char corpus, real
+Experiment 3 is the honest test: a real agent, a real long corpus, real
 trajectories. Because a live model is non-deterministic, it runs the whole
 baseline/PEEK comparison `--runs` times (default 3) and reports a *paired*
-per-run total delta with its spread. Validating it took two passes — and the
-first pass is the most instructive part.
+per-question turn delta with its spread. Getting a number worth trusting took
+three passes — and the dead ends along the way are the instructive part.
 
 ### First pass — a confound, not a result
 
@@ -195,46 +195,78 @@ Fix: an RLM is *defined* by reading its external context, so the agent now
 rejects a `FINAL` issued before any search has run, and is told the map is a
 navigation aid to confirm against `context` (see `rlm_agent.py`).
 
-### Second pass — the validated measurement
+### Second pass — no signal, and three reasons why
 
-Re-run, 3 runs × 4 questions, `claude` CLI default model:
+With the confound removed, a 3 runs × 4 questions re-run came back flat: a
+paired delta of +0.0 turns, accuracy back at parity. No measurable effect — and
+the writeup named three fixable causes. The **corpus was too easy**: a 72k-char
+handbook with topically-named chapters ("EMPLOYEE BENEFITS") lets a competent
+agent grep any fact in 3–4 turns flat, so there is almost no orientation cost to
+amortise. The **question stream was too short** for the map to mature. And **n
+was tiny** — a single CLI timeout had knocked a whole run out of the paired set,
+leaving n = 2.
+
+### Third pass — strengthen the setup, then re-measure
+
+This pass acts on all three:
+
+- **A harder corpus** (`corpus.py`, 72k → 116k chars, 9 → 13 chapters). Chapter
+  titles now name the *owning function* — "ABSENCE & SCHEDULING PROVISIONS", not
+  "holidays" — so the table of contents is no longer a shortcut; and every fact
+  is shadowed by two or three keyword *decoys* elsewhere that name the topic but
+  defer the figure. Finding a fact now costs genuine navigation.
+- **A longer stream** — 8 questions spanning 7 chapters across the handbook, so
+  the map has to accumulate orientation corpus-wide, not for one region.
+- **A robust estimator** — the paired delta is now computed per *question*
+  rather than per run, so one CLI timeout costs a single data point instead of a
+  whole run. 3 runs × 8 questions gives up to n = 24.
+
+Re-run, 3 runs × 8 questions, `claude` CLI default model (the `delta` column is
+PEEK − baseline; this run dropped nothing — 242 model calls, no timeouts):
 
 ```
-#  question                BASELINE        PEEK
-                           mean (range)    mean (range)
-1  parental leave (weeks)   3.7 (3-4)       3.0 (2-4)
-2  vacation days at 5 yrs   3.3 (3-4)       5.0 (4-6)
-3  home-office stipend      3.3 (2-4)       2.7 (2-3)
-4  paid company holidays    4.3 (2-6)       4.0 (3-5)
+#  question                   BASELINE       PEEK           delta
+                               mean (range)   mean (range)
+1  paid company holidays       6.7 (4-10)     3.7 (3-4)      −3.0
+2  parental leave (weeks)      5.7 (4-7)      5.7 (5-6)       0.0
+3  vacation days at 5 yrs      3.3 (2-4)      4.3 (3-7)      +1.0
+4  home-office stipend ($)     3.0 (2-4)      3.3 (3-4)      +0.3
+5  probation period (days)     2.0 (2)        4.0 (3-5)      +2.0
+6  prof.-dev. budget ($)       2.7 (2-3)      5.3 (4-6)      +2.6
+7  sabbatical service (yrs)    4.3 (3-5)      3.0 (3)        −1.3
+8  resignation notice (days)   3.0 (3)        4.7 (4-5)      +1.7
 
-paired total delta (PEEK − baseline):  +0.0 ± 4.2 turns   (n = 2 valid runs)
-answers correct:  baseline 12/12,  PEEK 11/12  (the 1 miss was a CLI timeout,
-                  not a wrong answer)
+paired delta (PEEK − baseline):  +0.42 ± 2.28 turns/question   (n = 24, 0 dropped)
+answers correct:  baseline 24/24,  PEEK 24/24
 ```
 
-**The validated result: no measurable effect.** With the accuracy confound
-removed, PEEK neither helps nor hurts here — the paired delta is 0.0 turns with
-a ±4.2 spread that completely swamps it. Accuracy is back to parity. PEEK did
-not make the agent faster on this corpus.
+**The headline is still "no net effect"** — +0.42 turns/question sits well
+inside the ±2.28 spread. But the per-question column is not noise, and it is the
+actual result: PEEK's sign tracks how hard the *baseline* found each question.
 
-Why no signal — and this is the honest part:
+- Where baseline orientation was **expensive, PEEK paid off.** Holidays cost the
+  baseline 6.7 turns — the worst question on the board, range 4–10 — and the map
+  cut it to 3.7, a 3.0-turn saving. Sabbatical: 4.3 → 3.0.
+- Where baseline orientation was **cheap, PEEK was a tax.** Probation (a flat
+  baseline 2.0 turns), the dev budget (2.7) and notice (3.0) all ran *slower*
+  with the map: +2.0, +2.6, +1.7. When a fact is one grep away, reading a
+  context map and then — as the agent is told to — re-confirming the answer
+  against `context` is pure overhead.
 
-1. **The corpus is too easy.** A competent agent greps it in 3–4 turns flat, so
-   there is almost no orientation cost for a cache to amortise. PEEK is designed
-   for contexts where orientation is genuinely expensive.
-2. **The question stream is too short.** PEEK's benefit is back-loaded (the map
-   must mature first); 4 questions barely reaches the payoff zone.
-3. **n is tiny.** One CLI timeout knocked a run out of the paired set, leaving
-   n = 2. A ±4.2 spread over 2 runs is not a measurement — it is a hint that
-   far more runs are needed.
+(The lone exception is parental leave: slow for the baseline at 5.7 turns, yet
+unchanged under PEEK. The pattern is a tendency, not a law.)
 
-What *is* solid: the full loop runs end to end, the agent produces genuine
-trajectories, and PEEK distills a genuinely good map — the final map (printed
-by the script) carries accurate char offsets and every exact domain constant.
-The artefact works; this experiment's regime simply does not reward it. A real
-benchmark would need a corpus where orientation costs many turns, longer
-question streams, and many more runs — that is the honest next step, not a
-claim of speed-up from this setup.
+So PEEK's value here is real but **conditional**: it amortises orientation only
+when orientation actually costs something. This corpus mixes genuinely buried
+facts with trivially greppable ones, and the mix averages to zero. The map is
+not the weak link — the final map the script prints at the end of each run
+carries accurate char offsets and every exact domain constant; the agent simply
+does not need it for the easy half of the stream.
+
+The honest next step is now sharper than "more runs": a corpus where *no* fact
+is cheaply greppable, so every query pays the orientation cost PEEK is built to
+cache. Until then, easy and hard questions mixed in one stream will keep washing
+the average back out to zero.
 
 ## Notes
 

--- a/peek-experiments/README.md
+++ b/peek-experiments/README.md
@@ -87,8 +87,9 @@ python experiment_2_policy_loop.py        # offline scripted LM (default, instan
 python experiment_2_policy_loop.py --live # real LM via the `claude` CLI
 python experiment_2_policy_loop.py --live --model opus   # pick the model
 
-python experiment_3_rlm.py                # end to end: real agent + real corpus (live, slow)
-python experiment_3_rlm.py --questions 2  # shorter / cheaper run
+python experiment_3_rlm.py                # end to end: 3 runs, real agent + corpus (live, slow)
+python experiment_3_rlm.py --runs 5       # more runs = tighter estimate
+python experiment_3_rlm.py --runs 1 --questions 2   # quick smoke check
 
 python claude_code_client.py              # one-call self-test of the live client
 
@@ -172,54 +173,68 @@ but the exact items, tags, and token counts differ run to run, and a real
 Cartographer tends to keep the map compact enough that the Evictor never
 triggers.
 
-## Experiment 3 — does the cache actually pay off?
+## Experiment 3 — does the cache measurably pay off?
 
 Experiment 3 is the honest test: a real agent, a real 72k-char corpus, real
-trajectories. One representative run (4 questions, `claude` CLI default model):
+trajectories. Because a live model is non-deterministic, it runs the whole
+baseline/PEEK comparison `--runs` times (default 3) and reports a *paired*
+per-run total delta with its spread. Validating it took two passes — and the
+first pass is the most instructive part.
+
+### First pass — a confound, not a result
+
+The initial multi-run looked like a PEEK win: −4.0 turns on average. It wasn't.
+Correctness told the real story — **baseline 11/12 answers right, PEEK only
+7/12** — and every wrong PEEK answer was a *1-turn* answer with **zero REPL
+searches**. A context map sitting in the prompt tempts the model to answer
+immediately from the map (or to guess) instead of reading the corpus. The
+"speed-up" was mostly the agent failing faster. Comparing turns across runs
+with different accuracy is meaningless.
+
+Fix: an RLM is *defined* by reading its external context, so the agent now
+rejects a `FINAL` issued before any search has run, and is told the map is a
+navigation aid to confirm against `context` (see `rlm_agent.py`).
+
+### Second pass — the validated measurement
+
+Re-run, 3 runs × 4 questions, `claude` CLI default model:
 
 ```
-#  question                     BASELINE   PEEK     map items
-1  parental leave (weeks)          3 ok     3 ok      0 -> 3
-2  vacation days at 5 yrs          3 ok     6 ok      3 -> 4
-3  home-office setup stipend       3 ok     2 ok      4 -> 5
-4  paid company holidays           3 ok     2 ok      5 -> 6
-   TOTAL model turns              12       13
+#  question                BASELINE        PEEK
+                           mean (range)    mean (range)
+1  parental leave (weeks)   3.7 (3-4)       3.0 (2-4)
+2  vacation days at 5 yrs   3.3 (3-4)       5.0 (4-6)
+3  home-office stipend      3.3 (2-4)       2.7 (2-3)
+4  paid company holidays    4.3 (2-6)       4.0 (3-5)
+
+paired total delta (PEEK − baseline):  +0.0 ± 4.2 turns   (n = 2 valid runs)
+answers correct:  baseline 12/12,  PEEK 11/12  (the 1 miss was a CLI timeout,
+                  not a wrong answer)
 ```
 
-All 8 answers were correct. The headline is *not* a clean win — PEEK spent 13
-turns to the baseline's 12. But the per-question shape is the real story, and
-it matches PEEK's theory closely:
+**The validated result: no measurable effect.** With the accuracy confound
+removed, PEEK neither helps nor hurts here — the paired delta is 0.0 turns with
+a ±4.2 spread that completely swamps it. Accuracy is back to parity. PEEK did
+not make the agent faster on this corpus.
 
-- **Q1 — tie.** The map starts empty, so the first question can't benefit. Its
-  trajectory is what *seeds* the map.
-- **Q2 — PEEK loses (6 vs 3).** After Q1 the map is only half-built: it had
-  distilled a pointer to the §1.2 "How to Use This Handbook" section — which is
-  exactly the *decoy* table-of-contents. With an immature map quoting a decoy,
-  the agent chased the phrase "vacation accrual" and wandered. **An immature
-  cache can mislead.**
-- **Q3, Q4 — PEEK wins (2 vs 3 each).** By now the Cartographer has distilled a
-  full section-by-section char-offset index. On Q4 the agent's first line of
-  code is literally `i = 40333` — the exact offset of §6.1 lifted straight from
-  the map — and it answers in 2 turns instead of 3.
+Why no signal — and this is the honest part:
 
-Takeaways from the real run:
+1. **The corpus is too easy.** A competent agent greps it in 3–4 turns flat, so
+   there is almost no orientation cost for a cache to amortise. PEEK is designed
+   for contexts where orientation is genuinely expensive.
+2. **The question stream is too short.** PEEK's benefit is back-loaded (the map
+   must mature first); 4 questions barely reaches the payoff zone.
+3. **n is tiny.** One CLI timeout knocked a run out of the paired set, leaving
+   n = 2. A ±4.2 spread over 2 runs is not a measurement — it is a hint that
+   far more runs are needed.
 
-1. **The cache has to mature before it helps.** Empty (Q1) → misleading (Q2) →
-   genuinely useful (Q3–Q4). PEEK's benefit is back-loaded; a 4-question run
-   barely reaches the payoff zone. The win compounds over a longer stream
-   against the now-mature, frozen map.
-2. **PEEK's value scales with orientation cost.** Here the baseline is already
-   fast — a competent agent greps this corpus in 3 turns flat — so there is
-   little rediscovery to amortise. PEEK helps most when orientation is genuinely
-   expensive (deeper structure, weaker search, costlier tools).
-3. **The final map is excellent even though the run netted even.** It ends with
-   a complete offset index and every exact fact (see the script's printed
-   FINAL CONTEXT MAP). The artefact is real and reusable; the 4-question budget
-   just wasn't long enough to cash it in.
-
-So: the full loop works end to end and the measurement is honest — PEEK neither
-magically wins nor fails here; it pays off precisely when and where its design
-predicts, and a short run on an easy corpus lands near break-even.
+What *is* solid: the full loop runs end to end, the agent produces genuine
+trajectories, and PEEK distills a genuinely good map — the final map (printed
+by the script) carries accurate char offsets and every exact domain constant.
+The artefact works; this experiment's regime simply does not reward it. A real
+benchmark would need a corpus where orientation costs many turns, longer
+question streams, and many more runs — that is the honest next step, not a
+claim of speed-up from this setup.
 
 ## Notes
 

--- a/peek-experiments/claude_code_client.py
+++ b/peek-experiments/claude_code_client.py
@@ -1,0 +1,179 @@
+"""An ``LMClient`` backed by the local Claude Code CLI (``claude``).
+
+PEEK's Distiller and Cartographer need a model behind the ``LMClient`` protocol
+(``completion`` + ``last_usage``). The reference clients all call a hosted API
+and need an API key. This client instead shells out to the ``claude`` binary in
+non-interactive print mode -- so PEEK runs against whatever model/credentials
+the local Claude Code install already has, with no API key of its own.
+
+Each ``completion`` call runs::
+
+    claude -p --output-format json --tools "" ...
+
+feeding the prompt on stdin (no ARG_MAX limit) and reading the ``result`` and
+``usage`` fields back out of the JSON envelope. Built-in tools are disabled and
+the system prompt is replaced with a minimal one, so the call behaves as a
+plain text completion rather than a coding-agent session.
+
+Run this file directly for a one-call self-test:  python claude_code_client.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+
+from peek.core.types import Usage
+
+_DEFAULT_SYSTEM_PROMPT = (
+    "You are a precise text-completion engine. Follow the user message exactly. "
+    "When it asks for a JSON object, output only that JSON object."
+)
+
+
+class ClaudeCodeError(RuntimeError):
+    """Raised when the ``claude`` CLI fails or returns an error envelope."""
+
+
+class ClaudeCodeClient:
+    """``LMClient`` that routes completions through the ``claude`` CLI.
+
+    Parameters
+    ----------
+    model:
+        Model alias or full name passed to ``--model`` (e.g. ``"opus"``,
+        ``"sonnet"``). ``None`` uses the CLI's default model.
+    timeout:
+        Per-call subprocess timeout, in seconds.
+    system_prompt:
+        Replaces Claude Code's default (coding-agent) system prompt.
+    claude_bin:
+        Path/name of the CLI binary.
+    verbose:
+        When true, print a one-line progress note to stdout before each call.
+    """
+
+    def __init__(
+        self,
+        model: str | None = None,
+        *,
+        timeout: float = 300.0,
+        system_prompt: str = _DEFAULT_SYSTEM_PROMPT,
+        claude_bin: str = "claude",
+        verbose: bool = False,
+    ) -> None:
+        resolved = shutil.which(claude_bin)
+        if resolved is None:
+            raise ClaudeCodeError(
+                f"the {claude_bin!r} CLI was not found on PATH -- this client "
+                "must run inside an environment that has Claude Code installed."
+            )
+        self._bin = resolved
+        # Run the subprocess from an empty, non-git directory: project-level
+        # CLAUDE.md, settings, and Stop hooks (e.g. the web harness's
+        # "uncommitted work" reminder) are discovered from the cwd, and would
+        # otherwise leak into -- and corrupt -- a plain completion.
+        self._workdir = os.path.join(tempfile.gettempdir(), "peek-claude-workdir")
+        os.makedirs(self._workdir, exist_ok=True)
+        self.model = model
+        self.timeout = timeout
+        self.system_prompt = system_prompt
+        self.verbose = verbose
+        self.calls = 0
+        self._last = Usage()
+
+    def _argv(self) -> list[str]:
+        argv = [
+            self._bin,
+            "-p",
+            "--output-format", "json",
+            "--tools", "",                 # pure text completion, no tool use
+            "--no-session-persistence",    # don't litter ~/.claude with sessions
+            "--strict-mcp-config",         # skip MCP server startup
+            "--system-prompt", self.system_prompt,
+        ]
+        if self.model:
+            argv += ["--model", self.model]
+        return argv
+
+    def completion(self, messages: list[dict]) -> str:
+        prompt = "\n\n".join(str(m.get("content", "")) for m in messages)
+        self.calls += 1
+        if self.verbose:
+            print(f"    [claude-code call #{self.calls}: {len(prompt)} prompt chars ...]")
+
+        try:
+            proc = subprocess.run(
+                self._argv(),
+                input=prompt,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+                cwd=self._workdir,
+            )
+        except subprocess.TimeoutExpired as e:
+            raise ClaudeCodeError(f"claude CLI timed out after {self.timeout}s") from e
+
+        if proc.returncode != 0:
+            raise ClaudeCodeError(
+                f"claude CLI exited {proc.returncode}: {proc.stderr.strip() or proc.stdout.strip()}"
+            )
+
+        try:
+            data = json.loads(proc.stdout)
+        except json.JSONDecodeError as e:
+            raise ClaudeCodeError(
+                f"could not parse claude CLI output as JSON: {proc.stdout[:300]!r}"
+            ) from e
+
+        if data.get("is_error"):
+            raise ClaudeCodeError(f"claude CLI returned an error: {data.get('result')}")
+
+        usage = data.get("usage") or {}
+        # Total input = fresh + cache-read + cache-creation tokens.
+        self._last = Usage(
+            input_tokens=(
+                int(usage.get("input_tokens", 0) or 0)
+                + int(usage.get("cache_read_input_tokens", 0) or 0)
+                + int(usage.get("cache_creation_input_tokens", 0) or 0)
+            ),
+            output_tokens=int(usage.get("output_tokens", 0) or 0),
+        )
+        return data.get("result", "") or ""
+
+    def last_usage(self) -> Usage:
+        return self._last
+
+
+def _self_test() -> None:
+    print("ClaudeCodeClient self-test -- one real `claude` call")
+    client = ClaudeCodeClient(verbose=True)
+    reply = client.completion(
+        [
+            {
+                "role": "user",
+                "content": (
+                    "Return ONLY this JSON object and nothing else: "
+                    '{"status": "ok", "answer": 7}'
+                ),
+            }
+        ]
+    )
+    print(f"  raw result : {reply!r}")
+    usage = client.last_usage()
+    print(f"  usage      : {usage.input_tokens} in / {usage.output_tokens} out")
+
+    # Confirm the reply round-trips through PEEK's own JSON extractor.
+    from peek._io import extract_json
+
+    parsed = extract_json(reply)
+    print(f"  parsed JSON: {parsed}")
+    ok = isinstance(parsed, dict) and parsed.get("status") == "ok"
+    print(f"  self-test  : {'PASS' if ok else 'FAIL'}")
+
+
+if __name__ == "__main__":
+    _self_test()

--- a/peek-experiments/claude_code_client.py
+++ b/peek-experiments/claude_code_client.py
@@ -25,6 +25,7 @@ import os
 import shutil
 import subprocess
 import tempfile
+import time
 
 from peek.core.types import Usage
 
@@ -48,6 +49,10 @@ class ClaudeCodeClient:
         ``"sonnet"``). ``None`` uses the CLI's default model.
     timeout:
         Per-call subprocess timeout, in seconds.
+    retries:
+        Number of extra attempts if a call times out or errors. The `claude`
+        CLI occasionally hangs or returns a transient error; a fresh process
+        usually succeeds.
     system_prompt:
         Replaces Claude Code's default (coding-agent) system prompt.
     claude_bin:
@@ -60,7 +65,8 @@ class ClaudeCodeClient:
         self,
         model: str | None = None,
         *,
-        timeout: float = 300.0,
+        timeout: float = 150.0,
+        retries: int = 2,
         system_prompt: str = _DEFAULT_SYSTEM_PROMPT,
         claude_bin: str = "claude",
         verbose: bool = False,
@@ -80,6 +86,7 @@ class ClaudeCodeClient:
         os.makedirs(self._workdir, exist_ok=True)
         self.model = model
         self.timeout = timeout
+        self.retries = retries
         self.system_prompt = system_prompt
         self.verbose = verbose
         self.calls = 0
@@ -105,6 +112,20 @@ class ClaudeCodeClient:
         if self.verbose:
             print(f"    [claude-code call #{self.calls}: {len(prompt)} prompt chars ...]")
 
+        last_err: ClaudeCodeError | None = None
+        for attempt in range(self.retries + 1):
+            try:
+                return self._invoke(prompt)
+            except ClaudeCodeError as e:
+                last_err = e
+                if attempt < self.retries:
+                    if self.verbose:
+                        print(f"    [attempt {attempt + 1} failed ({e}); retrying ...]")
+                    time.sleep(2 * (attempt + 1))
+        assert last_err is not None
+        raise last_err
+
+    def _invoke(self, prompt: str) -> str:
         try:
             proc = subprocess.run(
                 self._argv(),

--- a/peek-experiments/corpus.py
+++ b/peek-experiments/corpus.py
@@ -1,0 +1,228 @@
+"""Deterministic synthetic long context for the end-to-end RLM experiment.
+
+``build_corpus()`` returns a ~70k-character fictional "ACME Corp 2026 Employee
+Handbook": nine delimited chapters with sections, padded with filler so the
+document is far too large to drop into a prompt -- a real agent must search it.
+A handful of exact facts are embedded at known locations so the experiment's
+questions have unambiguous, checkable answers.
+
+The output is fully deterministic (seeded), so runs are reproducible.
+
+Run directly to print a size/structure summary:  python corpus.py
+"""
+
+from __future__ import annotations
+
+import random
+
+# Generic HR-handbook filler. Deliberately free of the answer keywords
+# ("parental", "vacation", "stipend", "holiday", ...) so keyword search stays
+# meaningful.
+_FILLER: tuple[str, ...] = (
+    "All team members are expected to maintain a professional and respectful demeanor in every workplace interaction.",
+    "Managers should schedule regular one-on-one meetings to discuss progress, priorities, and any concerns.",
+    "Company equipment must be used responsibly and kept secure at all times.",
+    "Questions about any policy in this handbook may be directed to the People Operations team.",
+    "ACME Corp is committed to fostering an inclusive environment where every individual can contribute fully.",
+    "Confidential business information must never be shared with parties outside the organization.",
+    "Employees are encouraged to pursue continuous learning and to share knowledge with their colleagues.",
+    "Workplace disagreements should be resolved promptly, constructively, and with mutual respect.",
+    "Each department maintains its own onboarding checklist to help new joiners become productive quickly.",
+    "Business travel must be approved in advance by the relevant department lead.",
+    "Records and documentation should be stored in the designated company systems, not on personal devices.",
+    "Feedback is most useful when it is specific, timely, and focused on observable behavior.",
+    "Safety procedures are reviewed periodically and all staff are expected to stay familiar with them.",
+    "Communication across time zones should favor written summaries so that no context is lost.",
+    "The company values transparency and encourages open discussion of goals and trade-offs.",
+    "Any suspected violation of company policy should be reported through the appropriate channel.",
+    "Performance expectations are set collaboratively at the start of each review cycle.",
+    "Meeting organizers should circulate an agenda beforehand and notes afterward.",
+    "Personal data handled by employees must be processed in line with the company's privacy standards.",
+    "New initiatives are typically piloted with a small group before a wider rollout.",
+    "Employees should keep their contact and emergency information current in the HR system.",
+    "Cross-functional projects benefit from a clearly named owner and a documented decision log.",
+    "The handbook is updated periodically and supersedes any prior version on its effective date.",
+    "Constructive collaboration is considered a core expectation of every role at the company.",
+)
+
+# (chapter title, [(section title, [embedded fact lines]), ...]).
+_CHAPTERS: tuple[tuple[str, tuple[tuple[str, tuple[str, ...]], ...]], ...] = (
+    (
+        "INTRODUCTION & COMPANY VALUES",
+        (
+            ("Welcome and Mission", ()),
+            (
+                "How to Use This Handbook",
+                (
+                    # Decoy: names every topic keyword but gives no numbers, so a
+                    # naive first keyword search lands here, not on the real fact.
+                    "Later chapters cover, among other topics, the company holiday "
+                    "schedule, paid parental leave, vacation accrual, and the "
+                    "home-office stipend for remote staff; consult the relevant "
+                    "chapter for the specific figures.",
+                ),
+            ),
+        ),
+    ),
+    (
+        "CODE OF CONDUCT",
+        (
+            ("Professional Behavior", ()),
+            ("Conflicts of Interest", ()),
+            ("Reporting Concerns", ()),
+        ),
+    ),
+    (
+        "WORKPLACE POLICIES",
+        (
+            (
+                "Working Hours and Attendance",
+                (
+                    # Decoy mention of "holiday" with no count.
+                    "The office is closed on each company holiday; the complete "
+                    "holiday schedule is published in the Time Off chapter.",
+                ),
+            ),
+            ("Use of Company Systems", ()),
+            ("Data Privacy and Security", ()),
+        ),
+    ),
+    (
+        "PERFORMANCE & DEVELOPMENT",
+        (
+            ("Review Cycles", ()),
+            ("Learning and Career Growth", ()),
+        ),
+    ),
+    (
+        "HEALTH & SAFETY",
+        (
+            ("Workplace Safety", ()),
+            ("Emergency Procedures", ()),
+        ),
+    ),
+    (
+        "TIME OFF & HOLIDAYS",
+        (
+            (
+                "Holiday Schedule",
+                (
+                    "ACME Corp observes exactly 13 paid company holidays during each calendar year.",
+                    "The 13 observed holidays are: New Year's Day, Martin Luther King Jr. Day, "
+                    "Presidents' Day, Memorial Day, Juneteenth, Independence Day, Labor Day, "
+                    "Veterans Day, Thanksgiving Day, the Day after Thanksgiving, Christmas Eve, "
+                    "Christmas Day, and New Year's Eve.",
+                ),
+            ),
+            (
+                "Floating Holidays",
+                (
+                    "In addition to the 13 fixed company holidays, every employee is granted "
+                    "2 floating holidays per year, which may be used at the employee's discretion.",
+                ),
+            ),
+        ),
+    ),
+    (
+        "EMPLOYEE BENEFITS",
+        (
+            (
+                "Health and Insurance Plans",
+                (
+                    # Decoy: names parental leave and vacation, no figures.
+                    "Beyond health and insurance coverage, this chapter also "
+                    "describes paid parental leave and vacation entitlements in "
+                    "the dedicated sections that follow.",
+                ),
+            ),
+            (
+                "Parental Leave",
+                (
+                    "ACME provides 19 weeks of fully paid parental leave to every eligible "
+                    "employee following the birth or adoption of a child.",
+                    "Parental leave must commence within the first 12 months after the birth "
+                    "or adoption and may be taken in up to three separate blocks.",
+                ),
+            ),
+            (
+                "Paid Time Off and Vacation Tiers",
+                (
+                    "Vacation days are granted according to length of service and accrue monthly.",
+                    "Employees with less than 1 year of service receive 8 vacation days per year.",
+                    "Employees with 1 to 4 years of service receive 14 vacation days per year.",
+                    "Employees with 5 to 9 years of service receive 23 vacation days per year.",
+                    "Employees with 10 or more years of service receive 29 vacation days per year.",
+                ),
+            ),
+        ),
+    ),
+    (
+        "COMPENSATION",
+        (
+            ("Salary Bands and Reviews", ()),
+            (
+                "Home-Office Stipend",
+                (
+                    "Remote and hybrid employees are eligible for a one-time home-office "
+                    "setup stipend of $685, paid with the first full paycheck.",
+                    "Employees also receive a recurring home-office stipend of $45 per month "
+                    "to offset internet and utility costs.",
+                ),
+            ),
+        ),
+    ),
+    (
+        "REMOTE WORK POLICY",
+        (
+            (
+                "Eligibility and Approval",
+                (
+                    # Decoy: mentions the stipend but defers the amount to Ch.8.
+                    "Remote and hybrid staff may also qualify for a home-office "
+                    "stipend; the exact stipend amounts are defined in the "
+                    "Compensation chapter, not in this section.",
+                ),
+            ),
+            ("Equipment and Reimbursement", ()),
+        ),
+    ),
+)
+
+_SECTION_TARGET_CHARS = 3000
+
+
+def _filler_block(seed: int, target_chars: int) -> str:
+    rng = random.Random(seed)
+    paragraphs: list[str] = []
+    size = 0
+    while size < target_chars:
+        sentences = [rng.choice(_FILLER) for _ in range(rng.randint(4, 7))]
+        para = " ".join(sentences)
+        paragraphs.append(para)
+        size += len(para) + 2
+    return "\n\n".join(paragraphs)
+
+
+def build_corpus() -> str:
+    """Return the full deterministic handbook text."""
+    parts: list[str] = [
+        "ACME CORP -- 2026 EMPLOYEE HANDBOOK",
+        "This document is the official handbook for all ACME Corp employees.",
+    ]
+    for ci, (title, sections) in enumerate(_CHAPTERS, start=1):
+        parts.append(f"\n\n=== CHAPTER {ci}: {title} ===\n")
+        for si, (stitle, facts) in enumerate(sections, start=1):
+            parts.append(f"\n--- Section {ci}.{si}: {stitle} ---\n")
+            parts.extend(facts)
+            parts.append(_filler_block(seed=ci * 100 + si, target_chars=_SECTION_TARGET_CHARS))
+    return "\n".join(parts)
+
+
+if __name__ == "__main__":
+    corpus = build_corpus()
+    print(f"corpus: {len(corpus):,} chars")
+    chapters = [ln for ln in corpus.splitlines() if ln.startswith("=== CHAPTER")]
+    sections = [ln for ln in corpus.splitlines() if ln.startswith("--- Section")]
+    print(f"chapters: {len(chapters)}, sections: {len(sections)}")
+    for ln in chapters:
+        print(f"  {ln}")

--- a/peek-experiments/corpus.py
+++ b/peek-experiments/corpus.py
@@ -1,8 +1,24 @@
 """Deterministic synthetic long context for the end-to-end RLM experiment.
 
-``build_corpus()`` returns a ~70k-character fictional "ACME Corp 2026 Employee
-Handbook": nine delimited chapters with sections, padded with filler so the
-document is far too large to drop into a prompt -- a real agent must search it.
+``build_corpus()`` returns a ~115k-character fictional "ACME Corp 2026 Employee
+Handbook": thirteen delimited chapters, each with several sections, padded with
+filler so the document is far too large to drop into a prompt -- a real agent
+must search it.
+
+The handbook is deliberately *orientation-hostile*, so that finding a fact
+genuinely costs navigation turns (which is the cost PEEK's context map is meant
+to amortise):
+
+* **Chapter titles name the owning function, not the topic.** A question asks
+  "how many paid holidays?"; the answer lives in a chapter called
+  "ABSENCE & SCHEDULING PROVISIONS". The agent cannot read the table of
+  contents and jump -- it has to open chapters and skim.
+* **Every fact is shadowed by decoys.** Each answer-bearing sentence sits in a
+  3k-char section next to two or three *decoy* sentences elsewhere in the
+  corpus that mention the same topic by keyword but give no figure ("the exact
+  amount appears in the dedicated section"). A naive keyword search lands on a
+  decoy first, so each fact costs several turns to pin down.
+
 A handful of exact facts are embedded at known locations so the experiment's
 questions have unambiguous, checkable answers.
 
@@ -16,19 +32,19 @@ from __future__ import annotations
 import random
 
 # Generic HR-handbook filler. Deliberately free of the answer keywords
-# ("parental", "vacation", "stipend", "holiday", ...) so keyword search stays
-# meaningful.
+# ("parental", "vacation", "stipend", "holiday", "probation", "sabbatical",
+# "notice", "development", ...) so keyword search stays meaningful.
 _FILLER: tuple[str, ...] = (
-    "All team members are expected to maintain a professional and respectful demeanor in every workplace interaction.",
+    "All team members are expected to maintain a courteous and respectful demeanor in every workplace interaction.",
     "Managers should schedule regular one-on-one meetings to discuss progress, priorities, and any concerns.",
     "Company equipment must be used responsibly and kept secure at all times.",
     "Questions about any policy in this handbook may be directed to the People Operations team.",
     "ACME Corp is committed to fostering an inclusive environment where every individual can contribute fully.",
     "Confidential business information must never be shared with parties outside the organization.",
-    "Employees are encouraged to pursue continuous learning and to share knowledge with their colleagues.",
+    "Employees are encouraged to pursue ongoing learning and to share knowledge with their colleagues.",
     "Workplace disagreements should be resolved promptly, constructively, and with mutual respect.",
     "Each department maintains its own onboarding checklist to help new joiners become productive quickly.",
-    "Business travel must be approved in advance by the relevant department lead.",
+    "Approved business travel must be arranged in advance with the relevant department lead.",
     "Records and documentation should be stored in the designated company systems, not on personal devices.",
     "Feedback is most useful when it is specific, timely, and focused on observable behavior.",
     "Safety procedures are reviewed periodically and all staff are expected to stay familiar with them.",
@@ -45,27 +61,35 @@ _FILLER: tuple[str, ...] = (
     "Constructive collaboration is considered a core expectation of every role at the company.",
 )
 
-# (chapter title, [(section title, [embedded fact lines]), ...]).
+# (chapter title, [(section title, [embedded fact / decoy lines]), ...]).
+#
+# Chapter titles deliberately describe the *owning function*, not the topic a
+# question asks about, so the table of contents is not a shortcut. Sections
+# whose lines are decoys mention a topic by keyword but withhold the figure.
 _CHAPTERS: tuple[tuple[str, tuple[tuple[str, tuple[str, ...]], ...]], ...] = (
     (
-        "INTRODUCTION & COMPANY VALUES",
+        "CHARTER, MISSION & GOVERNING PRINCIPLES",
         (
             ("Welcome and Mission", ()),
             (
                 "How to Use This Handbook",
                 (
-                    # Decoy: names every topic keyword but gives no numbers, so a
-                    # naive first keyword search lands here, not on the real fact.
-                    "Later chapters cover, among other topics, the company holiday "
-                    "schedule, paid parental leave, vacation accrual, and the "
-                    "home-office stipend for remote staff; consult the relevant "
-                    "chapter for the specific figures.",
+                    # Master decoy: names every topic keyword but gives no
+                    # numbers, so a naive first keyword search lands here.
+                    "Later parts of this handbook address, among many other "
+                    "matters, the schedule of observed company holidays, paid "
+                    "parental leave, the accrual of annual vacation, the "
+                    "home-office setup stipend, the new-hire probationary "
+                    "period, the professional-development budget, sabbatical "
+                    "eligibility, and the notice expected on resignation. In "
+                    "every case the binding figure appears only in the "
+                    "dedicated section, never in this overview.",
                 ),
             ),
         ),
     ),
     (
-        "CODE OF CONDUCT",
+        "STANDARDS OF BUSINESS CONDUCT",
         (
             ("Professional Behavior", ()),
             ("Conflicts of Interest", ()),
@@ -73,39 +97,93 @@ _CHAPTERS: tuple[tuple[str, tuple[tuple[str, tuple[str, ...]], ...]], ...] = (
         ),
     ),
     (
-        "WORKPLACE POLICIES",
+        "THE EMPLOYMENT RELATIONSHIP",
+        (
+            (
+                "Offer and Onboarding",
+                (
+                    # Decoy: mentions the probationary period, defers the count.
+                    "Onboarding concludes with the start of the probationary "
+                    "period; its exact duration is fixed in the section that "
+                    "follows and is not restated in this overview.",
+                ),
+            ),
+            (
+                "Probationary Period",
+                (
+                    "Every new employee at ACME serves an initial probationary "
+                    "period of 75 calendar days, measured from the official "
+                    "start date.",
+                    "During the 75-day probationary period either party may end "
+                    "the employment relationship with shortened notice.",
+                ),
+            ),
+            ("Employment Categories", ()),
+        ),
+    ),
+    (
+        "WORKING ARRANGEMENTS & FACILITIES",
         (
             (
                 "Working Hours and Attendance",
                 (
-                    # Decoy mention of "holiday" with no count.
-                    "The office is closed on each company holiday; the complete "
-                    "holiday schedule is published in the Time Off chapter.",
+                    # Decoy: mentions holidays with no count.
+                    "On every observed company holiday the office is closed; "
+                    "the full list and the exact count of holidays are "
+                    "published in the Absence & Scheduling chapter, not here.",
                 ),
             ),
-            ("Use of Company Systems", ()),
-            ("Data Privacy and Security", ()),
+            ("Use of Company Facilities", ()),
         ),
     ),
     (
-        "PERFORMANCE & DEVELOPMENT",
+        "PEOPLE DEVELOPMENT & PERFORMANCE",
         (
-            ("Review Cycles", ()),
-            ("Learning and Career Growth", ()),
+            (
+                "Review Cycles",
+                (
+                    # Decoy: mentions the development budget, defers the amount.
+                    "Each development plan is funded from the employee's "
+                    "professional-development budget, the amount of which is "
+                    "stated in the Professional Development section below.",
+                ),
+            ),
+            (
+                "Professional Development",
+                (
+                    "Each employee is allocated an annual "
+                    "professional-development budget of $1,650, which may be "
+                    "spent on courses, conferences, books, and certifications.",
+                    "The $1,650 professional-development budget does not roll "
+                    "over; any unused balance is forfeited at the end of the "
+                    "calendar year.",
+                ),
+            ),
+            ("Career Growth", ()),
         ),
     ),
     (
-        "HEALTH & SAFETY",
+        "HEALTH, SAFETY & WELLBEING",
         (
             ("Workplace Safety", ()),
             ("Emergency Procedures", ()),
+            ("Wellbeing Programs", ()),
         ),
     ),
     (
-        "TIME OFF & HOLIDAYS",
+        "ABSENCE & SCHEDULING PROVISIONS",
         (
             (
-                "Holiday Schedule",
+                "Scheduling Overview",
+                (
+                    # Decoy: mentions holidays, defers the count.
+                    "Scheduling spans observed holidays, discretionary days, "
+                    "and shift patterns; the precise count of paid holidays is "
+                    "given in the Observed Holidays section that follows.",
+                ),
+            ),
+            (
+                "Observed Holidays",
                 (
                     "ACME Corp observes exactly 13 paid company holidays during each calendar year.",
                     "The 13 observed holidays are: New Year's Day, Martin Luther King Jr. Day, "
@@ -115,7 +193,7 @@ _CHAPTERS: tuple[tuple[str, tuple[tuple[str, tuple[str, ...]], ...]], ...] = (
                 ),
             ),
             (
-                "Floating Holidays",
+                "Discretionary Days",
                 (
                     "In addition to the 13 fixed company holidays, every employee is granted "
                     "2 floating holidays per year, which may be used at the employee's discretion.",
@@ -124,19 +202,20 @@ _CHAPTERS: tuple[tuple[str, tuple[tuple[str, tuple[str, ...]], ...]], ...] = (
         ),
     ),
     (
-        "EMPLOYEE BENEFITS",
+        "FAMILY & LIFE-EVENT SUPPORT",
         (
             (
-                "Health and Insurance Plans",
+                "Life-Event Overview",
                 (
-                    # Decoy: names parental leave and vacation, no figures.
-                    "Beyond health and insurance coverage, this chapter also "
-                    "describes paid parental leave and vacation entitlements in "
-                    "the dedicated sections that follow.",
+                    # Decoy: names parental leave, withholds the figure.
+                    "This chapter covers parental leave alongside bereavement "
+                    "and caregiver leave; the specific parental-leave "
+                    "entitlement, in weeks, is stated only in the Parental "
+                    "Leave Provisions section.",
                 ),
             ),
             (
-                "Parental Leave",
+                "Parental Leave Provisions",
                 (
                     "ACME provides 19 weeks of fully paid parental leave to every eligible "
                     "employee following the birth or adoption of a child.",
@@ -144,24 +223,49 @@ _CHAPTERS: tuple[tuple[str, tuple[tuple[str, tuple[str, ...]], ...]], ...] = (
                     "or adoption and may be taken in up to three separate blocks.",
                 ),
             ),
+            ("Bereavement and Caregiver Leave", ()),
+        ),
+    ),
+    (
+        "SERVICE-BASED ENTITLEMENTS",
+        (
             (
-                "Paid Time Off and Vacation Tiers",
+                "Length-of-Service Overview",
                 (
-                    "Vacation days are granted according to length of service and accrue monthly.",
+                    # Decoy: names vacation and sabbatical, defers both figures.
+                    "Length of service governs both annual vacation accrual "
+                    "and sabbatical eligibility; the precise vacation tiers and "
+                    "the sabbatical service threshold appear in the two "
+                    "sections that follow this overview.",
+                ),
+            ),
+            (
+                "Annual Leave Accrual Tiers",
+                (
+                    "Annual vacation is granted according to length of service and accrues monthly.",
                     "Employees with less than 1 year of service receive 8 vacation days per year.",
                     "Employees with 1 to 4 years of service receive 14 vacation days per year.",
                     "Employees with 5 to 9 years of service receive 23 vacation days per year.",
                     "Employees with 10 or more years of service receive 29 vacation days per year.",
                 ),
             ),
+            (
+                "Sabbatical Eligibility",
+                (
+                    "Employees who reach 12 years of continuous service become eligible for a "
+                    "one-time paid sabbatical of 6 weeks.",
+                    "The 12-year sabbatical may be scheduled at any point after the eligibility "
+                    "date, subject to manager approval.",
+                ),
+            ),
         ),
     ),
     (
-        "COMPENSATION",
+        "TOTAL COMPENSATION & ALLOWANCES",
         (
             ("Salary Bands and Reviews", ()),
             (
-                "Home-Office Stipend",
+                "Remote-Work Allowances",
                 (
                     "Remote and hybrid employees are eligible for a one-time home-office "
                     "setup stipend of $685, paid with the first full paycheck.",
@@ -169,21 +273,45 @@ _CHAPTERS: tuple[tuple[str, tuple[tuple[str, tuple[str, ...]], ...]], ...] = (
                     "to offset internet and utility costs.",
                 ),
             ),
+            ("Recognition and Referrals", ()),
         ),
     ),
     (
-        "REMOTE WORK POLICY",
+        "DISTRIBUTED & HYBRID WORK",
         (
             (
                 "Eligibility and Approval",
                 (
-                    # Decoy: mentions the stipend but defers the amount to Ch.8.
-                    "Remote and hybrid staff may also qualify for a home-office "
-                    "stipend; the exact stipend amounts are defined in the "
-                    "Compensation chapter, not in this section.",
+                    # Decoy: mentions the stipend but defers the amount.
+                    "Approved remote and hybrid staff may claim the "
+                    "home-office stipend; the exact stipend amounts are "
+                    "defined in the Total Compensation chapter, not in this "
+                    "section.",
                 ),
             ),
             ("Equipment and Reimbursement", ()),
+        ),
+    ),
+    (
+        "TECHNOLOGY & INFORMATION SECURITY",
+        (
+            ("Acceptable Use", ()),
+            ("Data Protection", ()),
+        ),
+    ),
+    (
+        "SEPARATION & TRANSITIONS",
+        (
+            (
+                "Resignation and Notice",
+                (
+                    "An employee resigning from ACME is asked to provide 21 calendar days of "
+                    "written notice to their manager.",
+                    "The 21-day notice period may be waived only by mutual written agreement "
+                    "between the employee and ACME.",
+                ),
+            ),
+            ("Offboarding Checklist", ()),
         ),
     ),
 )

--- a/peek-experiments/experiment_1_mechanics.py
+++ b/peek-experiments/experiment_1_mechanics.py
@@ -1,0 +1,131 @@
+"""Experiment 1 -- PEEK core mechanics, with no LLM involved.
+
+PEEK has two layers: an LM-driven layer (Distiller + Cartographer) and a
+deterministic layer (the ContextMap data structure, the scoring convention,
+and the priority Evictor). This script exercises the deterministic layer
+directly -- the same surface peek's own unit tests cover -- with narrated
+output so the behaviour is visible.
+
+Run:  python experiment_1_mechanics.py
+"""
+
+from __future__ import annotations
+
+from peek import ContextMap, Operation, evict, update_scores
+
+
+def rule() -> None:
+    print("-" * 70)
+
+
+def show_map(cmap: ContextMap, title: str) -> None:
+    print(f"\n=== {title} ===")
+    rule()
+    print(cmap.text.rstrip())
+    rule()
+
+
+def main() -> None:
+    print("PEEK MECHANICS WALKTHROUGH (deterministic layer, no LLM)")
+
+    # 1. The initial map: five empty sections, zero items.
+    cmap = ContextMap.initial()
+    show_map(cmap, "1. ContextMap.initial()")
+    print(f"items: {cmap.items()}  (empty -- only section scaffolding)")
+
+    # 2. ADD operations. apply() mints stable, slug-prefixed, monotonic IDs.
+    #    The slug encodes the section: cr=context_roadmap, dc=domain_constants...
+    cmap = cmap.apply(
+        [
+            Operation(
+                type="ADD",
+                section="context_roadmap",
+                content="Corpus = 500 product reviews, newline-delimited.",
+            ),
+            Operation(
+                type="ADD",
+                section="context_roadmap",
+                content="Reviews 0-249 are electronics, 250-499 are home goods.",
+            ),
+            Operation(
+                type="ADD",
+                section="domain_constants",
+                content="Rating scale is 1-5; the 'verified' flag is 'Y' or 'N'.",
+            ),
+        ]
+    )
+    show_map(cmap, "2. After three ADD operations")
+    for it in cmap.items():
+        print(f"  {it.id:12s} section={it.section:18s} {it.content}")
+
+    # 3. REPLACE edits content in place; the item ID is preserved so the
+    #    Cartographer can keep referencing it across steps.
+    first_id = cmap.items()[0].id
+    cmap = cmap.apply(
+        [
+            Operation(
+                type="REPLACE",
+                item_id=first_id,
+                content="Corpus = 500 product reviews (38,402 chars), newline-delimited.",
+            )
+        ]
+    )
+    print(f"\n3. REPLACE {first_id}")
+    print(f"   id after replace: {cmap.items()[0].id}  (unchanged)")
+    print(f"   new content:      {cmap.items()[0].content}")
+
+    # 4. DELETE drops an item by ID.
+    last_id = cmap.items()[-1].id
+    cmap = cmap.apply([Operation(type="DELETE", item_id=last_id)])
+    print(f"\n4. DELETE {last_id}")
+    print(f"   remaining ids: {cmap.item_ids()}")
+
+    # 5. The scoring convention (peek.core.evictor.update_scores).
+    #    helpful = +1, harmful = -1, stale = -1, neutral = 0 (and registers).
+    scores = update_scores({}, {"a": "helpful", "b": "harmful", "c": "stale", "d": "neutral"})
+    print("\n5. Scoring convention")
+    print(f"   update_scores(helpful/harmful/stale/neutral) -> {scores}")
+    scores = update_scores(scores, {"a": "helpful", "b": "helpful"})
+    print(f"   'a' helpful again -> {scores['a']};  'b' helpful once -> {scores['b']} (was -1)")
+
+    # 6. The priority Evictor enforces a hard budget. Items are removed in
+    #    ascending (score, age) order -- lowest score first, oldest as the
+    #    tiebreak -- until the map fits. Here the token counter is len(str)
+    #    so the budget is measured in characters and easy to reason about.
+    big = ContextMap.initial().apply(
+        [
+            Operation(type="ADD", section="reusable_results", content=f"derived-result-block-{i}")
+            for i in range(6)
+        ]
+    )
+    ids = big.item_ids()
+    char_count = len
+    item_scores = {
+        ids[0]: 2,   # rescued by score
+        ids[1]: -1,  # harmful -> evicted early
+        ids[2]: 0,
+        ids[3]: 0,
+        ids[4]: 5,   # most protected
+        ids[5]: -3,  # evicted first
+    }
+    budget = char_count(big.text) - 95  # force several evictions
+
+    show_map(big, "6. A map of six items, about to be evicted")
+    print(f"   scores:     {item_scores}")
+    print(f"   full size:  {char_count(big.text)} chars   budget: {budget} chars")
+
+    kept = evict(big, item_scores, budget, char_count)
+    survivors = kept.item_ids()
+    evicted = [i for i in ids if i not in survivors]
+    print(f"   evicted (ascending score, then oldest): {evicted}")
+    print(f"   survivors (highest score / youngest):   {survivors}")
+    print(f"   final size: {char_count(kept.text)} chars  (<= budget)")
+    print(
+        "\n   Note: the Evictor is section-agnostic -- it trusts the score alone.\n"
+        "   What protects a valuable item from eviction is the Distiller\n"
+        "   repeatedly tagging it 'helpful', not which section it lives in."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/peek-experiments/experiment_2_policy_loop.py
+++ b/peek-experiments/experiment_2_policy_loop.py
@@ -12,15 +12,23 @@ external context -- a fictional ~41k-char "ACME Corp 2026 Employee Handbook".
 Watch the context map bootstrap itself from empty, self-correct a misleading
 entry, and then get squeezed by the token budget.
 
-Run:  python experiment_2_policy_loop.py
+Two backends:
+  python experiment_2_policy_loop.py            # offline scripted LM (default)
+  python experiment_2_policy_loop.py --live     # real LM via the `claude` CLI
+
+In --live mode the canned scripts below are ignored: the Distiller and
+Cartographer are driven by an actual model through ClaudeCodeClient, so the
+diagnoses, tags, and edits are genuine (and non-deterministic).
 """
 
 from __future__ import annotations
 
-import json
+import argparse
 
 from peek import CachePolicy
+from peek._io import extract_json
 
+from claude_code_client import ClaudeCodeClient
 from scripted_client import ScriptedLMClient, id_of, tags_for
 
 TOKEN_BUDGET = 440
@@ -272,10 +280,18 @@ def banner(text: str) -> None:
     print("=" * 74)
 
 
-def main() -> None:
-    banner("PEEK CACHE-POLICY LOOP  --  scripted LM, real PEEK control flow")
+def main(*, live: bool = False, model: str | None = None) -> None:
+    if live:
+        banner("PEEK CACHE-POLICY LOOP  --  live LM via the `claude` CLI")
+        client: ScriptedLMClient | ClaudeCodeClient = ClaudeCodeClient(
+            model=model, verbose=True
+        )
+        backend = f"live (Claude Code CLI{', model=' + model if model else ''})"
+    else:
+        banner("PEEK CACHE-POLICY LOOP  --  scripted LM, real PEEK control flow")
+        client = ScriptedLMClient(DISTILLER_SCRIPT, CARTOGRAPHER_SCRIPT)
+        backend = "scripted (offline stub)"
 
-    client = ScriptedLMClient(DISTILLER_SCRIPT, CARTOGRAPHER_SCRIPT)
     policy = CachePolicy(
         client=client,
         token_budget=TOKEN_BUDGET,
@@ -284,6 +300,7 @@ def main() -> None:
     tok = policy.token_counter
     assert tok is not None
 
+    print(f"backend = {backend}")
     print(f"token_budget = {TOKEN_BUDGET}    evolve_steps = {EVOLVE_STEPS}")
     print(f"initial map: {len(policy.cmap.items())} items, {tok(policy.current_map_text)} tokens")
 
@@ -306,8 +323,17 @@ def main() -> None:
             continue
 
         ids_after = policy.cmap.item_ids()
-        cart = json.loads(result.cartographer_raw)
-        deleted = {o["item_id"] for o in cart["operations"] if o["type"] == "DELETE"}
+        # cartographer_raw is the model's raw text -- pure JSON from the scripted
+        # stub, but often fenced/prefaced by a live model. extract_json (PEEK's
+        # own helper) copes with both, so eviction and Cartographer DELETEs can
+        # be told apart for the per-step report.
+        cart = extract_json(result.cartographer_raw)
+        cart_ops = cart.get("operations", []) if isinstance(cart, dict) else []
+        deleted = {
+            o["item_id"]
+            for o in cart_ops
+            if isinstance(o, dict) and o.get("type") == "DELETE" and o.get("item_id")
+        }
         removed = set(ids_before) - set(ids_after)
         evicted = removed - deleted
         total_in += result.usage.input_tokens
@@ -331,7 +357,8 @@ def main() -> None:
     banner("RUN SUMMARY")
     print(f"LM calls            : {client.calls} "
           f"(2 per evolving step x {EVOLVE_STEPS} steps)")
-    print(f"scripted token usage: {total_in} in / {total_out} out")
+    usage_label = "real token usage" if live else "scripted token usage"
+    print(f"{usage_label:20s}: {total_in} in / {total_out} out")
     print(f"final map           : {len(policy.cmap.items())} items, "
           f"{tok(policy.current_map_text)}/{TOKEN_BUDGET} tokens")
     print(f"final scores        : {policy.scores}")
@@ -352,4 +379,18 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--live",
+        action="store_true",
+        help="drive the Distiller/Cartographer with a real model via the "
+        "`claude` CLI instead of the offline scripted stub",
+    )
+    parser.add_argument(
+        "--model",
+        default=None,
+        help="model alias/name for --live mode (e.g. 'opus', 'sonnet'); "
+        "defaults to the claude CLI's default model",
+    )
+    args = parser.parse_args()
+    main(live=args.live, model=args.model)

--- a/peek-experiments/experiment_2_policy_loop.py
+++ b/peek-experiments/experiment_2_policy_loop.py
@@ -1,0 +1,355 @@
+"""Experiment 2 -- the full PEEK CachePolicy loop, driven by a scripted LM.
+
+This runs PEEK exactly as the README's "minimal loop" snippet does, but the
+``LMClient`` is a ``ScriptedLMClient`` that replays canned Distiller and
+Cartographer JSON instead of calling a real model. Every other moving part is
+the genuine PEEK code: the Distiller/Cartographer wrappers, JSON extraction,
+``ContextMap.apply``, the score bookkeeping, the priority Evictor, the
+``evolve_steps`` freeze, and ``save``/``load``.
+
+Scenario: an RLM agent answers a stream of questions about one recurring
+external context -- a fictional ~41k-char "ACME Corp 2026 Employee Handbook".
+Watch the context map bootstrap itself from empty, self-correct a misleading
+entry, and then get squeezed by the token budget.
+
+Run:  python experiment_2_policy_loop.py
+"""
+
+from __future__ import annotations
+
+import json
+
+from peek import CachePolicy
+
+from scripted_client import ScriptedLMClient, id_of, tags_for
+
+TOKEN_BUDGET = 440
+EVOLVE_STEPS = 4
+
+# --- The recurring agent workload: (question, one-line trajectory summary) ---
+WORKLOAD = [
+    (
+        "What is ACME's parental leave policy?",
+        "Iter 1-6: grep'd 41k chars for 'parental'/'leave'/'benefit', located "
+        "'=== CHAPTER 7: BENEFITS ==='. Iter 7-9: read sec 7.3 and answered.",
+    ),
+    (
+        "How many vacation days does a 5-year employee get?",
+        "Iter 1-3: re-scanned for chapter delimiters. Iter 4-7: found the PTO "
+        "tier table in sec 7.5, computed 20 days for 5-year tenure.",
+    ),
+    (
+        "What is the remote-work home-office stipend?",
+        "Iter 1-3: followed cached pointer to Ch.9, which only states "
+        "eligibility. Iter 4-8: re-searched, found the amount in Ch.8 sec 8.4.",
+    ),
+    (
+        "List the company-observed holidays.",
+        "Iter 1-2: naive split on 'CHAPTER' over-matched body text. Iter 3-6: "
+        "anchored on the full delimiter, found Ch.6, extracted 11 holidays.",
+    ),
+    (
+        "What is the bereavement leave allowance?",
+        "(evolution frozen -- agent runs against the final cached map)",
+    ),
+]
+
+# --- Scripted Distiller responses (one per evolving step) -------------------
+# A dict is used verbatim; a callable receives the prompt so it can tag the
+# live, run-time item IDs embedded in the context map.
+
+DISTILLER_SCRIPT = [
+    # Step 1: the map is empty, so there is nothing to tag yet.
+    {
+        "diagnosis": (
+            "Agent spent 6 of 9 iterations just locating the right chapter -- "
+            "pure orientation work. The map is empty so nothing was reused; the "
+            "chapter layout it discovered should be cached."
+        ),
+        "item_tags": {},
+        "cache_candidates": [
+            {
+                "section": "context_roadmap",
+                "value": "9-chapter handbook, '=== CHAPTER N ===' delimiters; benefits in Ch.7.",
+                "transferability": "any question that must first locate a topic",
+                "rationale": "structural layout, not an answer to this question",
+            }
+        ],
+    },
+    # Step 2: three roadmap items now exist.
+    lambda p: {
+        "diagnosis": (
+            "The cached chapter index let the agent jump toward Ch.7, but it "
+            "still re-scanned delimiters for 3 iterations and then read the PTO "
+            "tier table -- that table is a domain constant worth caching."
+        ),
+        "item_tags": tags_for(
+            p,
+            [
+                ("Handbook = 9 chapters", "helpful"),
+                ("Ch.7 Benefits covers", "helpful"),
+                ("home-office stipend", "neutral"),
+            ],
+        ),
+        "cache_candidates": [
+            {
+                "section": "domain_constants",
+                "value": "PTO tiers by tenure (sec 7.5).",
+                "transferability": "any tenure/leave/accrual question",
+                "rationale": "exact reference values the context defines",
+            }
+        ],
+    },
+    # Step 3: the Ch.9 roadmap pointer turns out to be misleading.
+    lambda p: {
+        "diagnosis": (
+            "The Ch.9 roadmap item sent the agent to the wrong chapter for the "
+            "stipend AMOUNT: Ch.9 states eligibility only, the dollar figure is "
+            "in Ch.8 (Compensation). That pointer is misleading -- 3 wasted "
+            "iterations -- and should be corrected."
+        ),
+        "item_tags": tags_for(
+            p,
+            [
+                ("Handbook = 9 chapters", "helpful"),
+                ("Ch.7 Benefits covers", "neutral"),
+                ("home-office stipend", "harmful"),
+                ("ACME Corp's 2026", "neutral"),
+                ("PTO/vacation tiers", "neutral"),
+            ],
+        ),
+        "cache_candidates": [
+            {
+                "section": "context_roadmap",
+                "value": "Ch.8 holds dollar figures; Ch.9 holds eligibility.",
+                "transferability": "any question mixing amounts and policy",
+                "rationale": "corrects a misleading structural pointer",
+            }
+        ],
+    },
+    # Step 4: the parsing-schema item paid off; holidays live in Ch.6.
+    lambda p: {
+        "diagnosis": (
+            "The parsing-schema item paid off -- the agent anchored on the full "
+            "delimiter after a naive 'CHAPTER' split over-matched body text. "
+            "Holidays are in Ch.6; cache the location and the holiday list."
+        ),
+        "item_tags": tags_for(
+            p,
+            [
+                ("Handbook = 9 chapters", "helpful"),
+                ("Ch.7 Benefits covers", "neutral"),
+                ("ACME Corp's 2026", "helpful"),
+                ("PTO/vacation tiers", "neutral"),
+                ("Ch.8 Compensation defines", "helpful"),
+                ("(sec 8.4)", "neutral"),
+                ("Chapter delimiter:", "helpful"),
+            ],
+        ),
+        "cache_candidates": [
+            {
+                "section": "domain_constants",
+                "value": "The 11-holiday list.",
+                "transferability": "any time-off / holiday question",
+                "rationale": "exact enumerated set defined by the context",
+            }
+        ],
+    },
+]
+
+# --- Scripted Cartographer responses (one per evolving step) ----------------
+
+CARTOGRAPHER_SCRIPT = [
+    # Step 1: bootstrap the chapter roadmap from nothing.
+    {
+        "reasoning": "Cache the chapter layout so future questions skip the orientation grep.",
+        "operations": [
+            {
+                "type": "ADD",
+                "section": "context_roadmap",
+                "content": (
+                    "Handbook = 9 chapters, delimiter '=== CHAPTER N: TITLE ==='. "
+                    "Ch.1 Intro, Ch.2-3 Conduct, Ch.6 Time Off, Ch.7 Benefits, "
+                    "Ch.8 Compensation, Ch.9 Remote Work."
+                ),
+            },
+            {
+                "type": "ADD",
+                "section": "context_roadmap",
+                "content": "Ch.7 Benefits covers health plans, parental leave (sec 7.3), PTO tiers (sec 7.5).",
+            },
+            {
+                "type": "ADD",
+                "section": "context_roadmap",
+                "content": "Ch.9 Remote Work covers eligibility, the home-office stipend, and equipment.",
+            },
+        ],
+    },
+    # Step 2: add a global description and the PTO tier table.
+    {
+        "reasoning": "Add a global description of the document and cache the exact PTO tier table.",
+        "operations": [
+            {
+                "type": "ADD",
+                "section": "context_understanding",
+                "content": "Document is ACME Corp's 2026 US employee handbook: formal HR policy for full-time staff.",
+            },
+            {
+                "type": "ADD",
+                "section": "domain_constants",
+                "content": "PTO/vacation tiers (sec 7.5), accrued monthly: <1yr=10 days, 1-4yr=15, 5-9yr=20, 10+yr=25.",
+            },
+        ],
+    },
+    # Step 3: delete the misleading pointer, add the correct cross-reference,
+    # the stipend constant, and the parsing schema.
+    lambda p: {
+        "reasoning": (
+            "Delete the misleading Ch.9 pointer, replace it with the correct "
+            "Ch.8/Ch.9 cross-reference, and cache the stipend figure and delimiters."
+        ),
+        "operations": [
+            {"type": "DELETE", "item_id": id_of(p, "home-office stipend")},
+            {
+                "type": "ADD",
+                "section": "context_roadmap",
+                "content": (
+                    "Ch.8 Compensation defines ALL dollar figures (salary, stipends, bonuses); "
+                    "Ch.9 Remote Work defines eligibility only -- cross-reference Ch.8 for amounts."
+                ),
+            },
+            {
+                "type": "ADD",
+                "section": "domain_constants",
+                "content": (
+                    "Home-office stipend (sec 8.4): $750 one-time setup + $50/month; "
+                    "needs manager approval and 90-day tenure."
+                ),
+            },
+            {
+                "type": "ADD",
+                "section": "parsing_schema",
+                "content": "Chapter delimiter: '=== CHAPTER N: TITLE ==='. Section refs 'sec 8.4'. Money '$1,200'.",
+            },
+        ],
+    },
+    # Step 4: cache Ch.6, the holiday list, an offset index, and a pitfall.
+    # Four ADDs push the map over budget and trigger the Evictor.
+    {
+        "reasoning": "Cache the Ch.6 location, the exact holiday list, the offset index, and the delimiter pitfall.",
+        "operations": [
+            {
+                "type": "ADD",
+                "section": "context_roadmap",
+                "content": "Ch.6 'Time Off & Holidays' lists observed holidays and floating-holiday policy (sec 6.2).",
+            },
+            {
+                "type": "ADD",
+                "section": "domain_constants",
+                "content": (
+                    "11 paid holidays: New Year's, MLK, Presidents', Memorial, Juneteenth, "
+                    "Independence, Labor, Thanksgiving + day after, Christmas Eve, Christmas; plus 2 floating/yr."
+                ),
+            },
+            {
+                "type": "ADD",
+                "section": "reusable_results",
+                "content": "Agent-built char-offset index (~41k total): Ch.1@0, Ch.6@~18k, Ch.7@~24k, Ch.8@~31k, Ch.9@~36k.",
+            },
+            {
+                "type": "ADD",
+                "section": "error_patterns",
+                "content": "Splitting on bare 'CHAPTER' over-matches body text ('see Chapter 8'); anchor on '=== CHAPTER N:'.",
+            },
+        ],
+    },
+]
+
+
+def banner(text: str) -> None:
+    print("\n" + "=" * 74)
+    print(text)
+    print("=" * 74)
+
+
+def main() -> None:
+    banner("PEEK CACHE-POLICY LOOP  --  scripted LM, real PEEK control flow")
+
+    client = ScriptedLMClient(DISTILLER_SCRIPT, CARTOGRAPHER_SCRIPT)
+    policy = CachePolicy(
+        client=client,
+        token_budget=TOKEN_BUDGET,
+        evolve_steps=EVOLVE_STEPS,
+    )
+    tok = policy.token_counter
+    assert tok is not None
+
+    print(f"token_budget = {TOKEN_BUDGET}    evolve_steps = {EVOLVE_STEPS}")
+    print(f"initial map: {len(policy.cmap.items())} items, {tok(policy.current_map_text)} tokens")
+
+    total_in = total_out = 0
+
+    for step, (question, trajectory) in enumerate(WORKLOAD, start=1):
+        banner(f"STEP {step}   Q: {question}")
+        print(f"agent trajectory: {trajectory}")
+
+        ids_before = policy.cmap.item_ids()
+        result = policy.update(trajectory=trajectory, question=question)
+
+        if result is None:
+            print(
+                f"\n  >> evolution FROZEN (evolve_steps={EVOLVE_STEPS} reached). "
+                "0 LM calls; map reused as-is."
+            )
+            print(f"  map unchanged: {len(policy.cmap.items())} items, "
+                  f"{tok(policy.current_map_text)} tokens")
+            continue
+
+        ids_after = policy.cmap.item_ids()
+        cart = json.loads(result.cartographer_raw)
+        deleted = {o["item_id"] for o in cart["operations"] if o["type"] == "DELETE"}
+        removed = set(ids_before) - set(ids_after)
+        evicted = removed - deleted
+        total_in += result.usage.input_tokens
+        total_out += result.usage.output_tokens
+
+        print(f"\n  Distiller   : {result.distiller.diagnosis}")
+        if result.distiller.item_tags:
+            print(f"  item tags   : {result.distiller.item_tags}")
+        print(f"  Cartographer: {result.operations_applied} operation(s) applied")
+        if deleted:
+            print(f"  deleted     : {sorted(deleted)}  (Cartographer DELETE)")
+        if evicted:
+            print(f"  EVICTED     : {sorted(evicted)}  (Evictor: over budget)")
+        print(f"  scores      : {policy.scores}")
+        print(f"  map now     : {len(ids_after)} items, "
+              f"{tok(result.map_text)} / {TOKEN_BUDGET} tokens")
+
+    banner("FINAL CONTEXT MAP")
+    print(policy.current_map_text.rstrip())
+
+    banner("RUN SUMMARY")
+    print(f"LM calls            : {client.calls} "
+          f"(2 per evolving step x {EVOLVE_STEPS} steps)")
+    print(f"scripted token usage: {total_in} in / {total_out} out")
+    print(f"final map           : {len(policy.cmap.items())} items, "
+          f"{tok(policy.current_map_text)}/{TOKEN_BUDGET} tokens")
+    print(f"final scores        : {policy.scores}")
+
+    # save / load round-trip -- the persisted map is what you prepend to the
+    # next agent call (see the README's minimal-loop snippet).
+    out_path = "output/acme-handbook.peek.json"
+    policy.save(out_path)
+    reloaded = CachePolicy.load(
+        out_path,
+        client=ScriptedLMClient([], []),
+        token_counter=policy.token_counter,
+    )
+    match = reloaded.current_map_text == policy.current_map_text
+    print(f"\nsaved -> {out_path}; reloaded map matches original: {match}")
+    print(f"reloaded policy: steps={reloaded.steps}, evolving={reloaded.evolving} "
+          "(frozen -- ready to serve future questions)")
+
+
+if __name__ == "__main__":
+    main()

--- a/peek-experiments/experiment_3_rlm.py
+++ b/peek-experiments/experiment_3_rlm.py
@@ -2,7 +2,7 @@
 
 Experiments 1 and 2 exercise PEEK's machinery on *canned* trajectories. This
 one closes the loop: a real RLM agent (``rlm_agent.RLMAgent``) actually explores
-a real ~72k-char long context (``corpus.build_corpus``) by running code in a
+a real ~115k-char long context (``corpus.build_corpus``) by running code in a
 REPL, and PEEK's ``CachePolicy`` distills each genuine trajectory into the map.
 
 Each run answers the same question stream twice:
@@ -16,11 +16,11 @@ per-question means and a paired (PEEK - baseline) total delta with its spread,
 so the comparison is something you can actually read a signal off of (n
 permitting).
 
-Needs the `claude` CLI. This makes a LOT of model calls -- roughly 33 per run.
+Needs the `claude` CLI. This makes a LOT of model calls -- well over 100 per run.
 
-  python experiment_3_rlm.py                    # 3 runs, 4 questions
+  python experiment_3_rlm.py                    # 3 runs, 8 questions
   python experiment_3_rlm.py --runs 5           # more runs = tighter estimate
-  python experiment_3_rlm.py --runs 1 --questions 2   # quick smoke check
+  python experiment_3_rlm.py --runs 1 --questions 3   # quick smoke check
 """
 
 from __future__ import annotations
@@ -34,9 +34,18 @@ from claude_code_client import ClaudeCodeClient, ClaudeCodeError
 from corpus import build_corpus
 from rlm_agent import RLMAgent, RLMResult
 
-# Facts use deliberately non-standard values (19 weeks, 23 days, $685, 13) so
+# Facts use deliberately non-standard values (13 holidays, 19 weeks, 23 days,
+# $685, 75-day probation, $1,650 budget, 12-year sabbatical, 21-day notice) so
 # the agent cannot shortcut with a plausible guess -- it must read the corpus.
+# The 8 questions span 7 chapters spread across the handbook, so the context
+# map has to accumulate orientation knowledge corpus-wide rather than for one
+# region.
 QUESTIONS = [
+    {
+        "label": "paid company holidays",
+        "q": "How many paid company holidays does ACME observe each year?",
+        "expect": "13",
+    },
     {
         "label": "parental leave (weeks)",
         "q": "How many weeks of paid parental leave does ACME provide?",
@@ -48,18 +57,33 @@ QUESTIONS = [
         "expect": "23",
     },
     {
-        "label": "home-office setup stipend",
+        "label": "home-office stipend ($)",
         "q": "What is the dollar amount of the one-time home-office setup stipend?",
         "expect": "685",
     },
     {
-        "label": "paid company holidays",
-        "q": "How many paid company holidays does ACME observe each year?",
-        "expect": "13",
+        "label": "probation period (days)",
+        "q": "How many calendar days is the initial probationary period for a new employee?",
+        "expect": "75",
+    },
+    {
+        "label": "prof.-dev. budget ($)",
+        "q": "What is the annual professional-development budget per employee, in dollars?",
+        "expect": "1650",
+    },
+    {
+        "label": "sabbatical service (yrs)",
+        "q": "After how many years of continuous service does an employee become eligible for a sabbatical?",
+        "expect": "12",
+    },
+    {
+        "label": "resignation notice (days)",
+        "q": "How many calendar days of written notice should a resigning employee provide?",
+        "expect": "21",
     },
 ]
 
-TOKEN_BUDGET = 800
+TOKEN_BUDGET = 1200
 
 
 def banner(text: str) -> None:
@@ -69,7 +93,9 @@ def banner(text: str) -> None:
 
 
 def correct(answer: str, expect: str) -> bool:
-    return expect.lower() in answer.lower()
+    # Comma-insensitive substring match, so an answer of "$1,650" still
+    # satisfies an expected token of "1650".
+    return expect.replace(",", "").lower() in answer.replace(",", "").lower()
 
 
 def safe_run(agent: RLMAgent, question: str, context: str, context_map: str) -> RLMResult:
@@ -126,7 +152,8 @@ def main(*, n_questions: int, runs: int, model: str | None, max_iters: int) -> N
     corpus = build_corpus()
 
     banner("EXPERIMENT 3 -- PEEK end to end with a real RLM agent")
-    print(f"corpus      : {len(corpus):,} chars, 9 chapters")
+    n_chapters = corpus.count("=== CHAPTER ")
+    print(f"corpus      : {len(corpus):,} chars, {n_chapters} chapters")
     print(f"questions   : {len(questions)}   runs: {runs}")
     print(f"agent model : {model or 'claude CLI default'}   max_iterations={max_iters}")
 
@@ -224,7 +251,7 @@ if __name__ == "__main__":
                         help="how many questions from the stream to run")
     parser.add_argument("--model", default=None,
                         help="model alias/name for the `claude` CLI (e.g. 'opus')")
-    parser.add_argument("--max-iters", type=int, default=8,
+    parser.add_argument("--max-iters", type=int, default=12,
                         help="max REPL turns per question before giving up")
     args = parser.parse_args()
     main(

--- a/peek-experiments/experiment_3_rlm.py
+++ b/peek-experiments/experiment_3_rlm.py
@@ -157,8 +157,11 @@ def main(*, n_questions: int, runs: int, model: str | None, max_iters: int) -> N
     print(f"questions   : {len(questions)}   runs: {runs}")
     print(f"agent model : {model or 'claude CLI default'}   max_iterations={max_iters}")
 
-    agent_client = ClaudeCodeClient(model=model)
-    peek_client = ClaudeCodeClient(model=model)
+    # A longer timeout and an extra retry: the larger corpus makes agent
+    # trajectories longer, and an occasional slow/hung `claude` call should not
+    # cost a paired data point.
+    agent_client = ClaudeCodeClient(model=model, timeout=240.0, retries=3)
+    peek_client = ClaudeCodeClient(model=model, timeout=240.0, retries=3)
     agent = RLMAgent(agent_client, max_iterations=max_iters, verbose=True)
 
     # all_baseline[run][question] = (RLMResult, ok); same shape for all_peek.
@@ -191,43 +194,47 @@ def main(*, n_questions: int, runs: int, model: str | None, max_iters: int) -> N
         print(f"{i + 1:<3}{item['label']:<28}{_fmt(b):>18}{_fmt(p):>18}")
     print("-" * 67)
 
-    # Paired per-run totals -- only runs where every question completed in
-    # both conditions are comparable.
-    deltas: list[int] = []
-    b_totals: list[int] = []
-    p_totals: list[int] = []
+    # Paired comparison at the (run, question) level: a pair counts only when
+    # both conditions answered that question without a CLI failure. Pairing per
+    # question rather than per run means one timeout drops a single pair, not a
+    # whole run -- so the usable sample is up to questions x runs, the n the
+    # earlier 4-question version never had enough of.
+    pairs: list[tuple[int, int]] = []  # (baseline_turns, peek_turns)
     for r in range(runs):
-        b_ok = all(res.stopped != "error" for res, _ in all_baseline[r])
-        p_ok = all(res.stopped != "error" for res, _ in all_peek[r])
-        if b_ok and p_ok:
-            bt = sum(res.turns for res, _ in all_baseline[r])
-            pt = sum(res.turns for res, _ in all_peek[r])
-            b_totals.append(bt)
-            p_totals.append(pt)
-            deltas.append(pt - bt)
+        for i in range(len(questions)):
+            b_res = all_baseline[r][i][0]
+            p_res = all_peek[r][i][0]
+            if b_res.stopped != "error" and p_res.stopped != "error":
+                pairs.append((b_res.turns, p_res.turns))
 
-    banner("PAIRED COMPARISON -- total turns per run (PEEK vs baseline)")
-    if not deltas:
-        print("  No run completed every question in both conditions -- cannot compare.")
+    banner("PAIRED COMPARISON -- per-question turn delta (PEEK - baseline)")
+    attempted = len(questions) * runs
+    dropped = attempted - len(pairs)
+    if not pairs:
+        print("  No question completed in both conditions -- cannot compare.")
     else:
-        for idx, (bt, pt) in enumerate(zip(b_totals, p_totals), start=1):
-            print(f"  run {idx}: baseline {bt:>3}  |  PEEK {pt:>3}  |  delta {pt - bt:+d}")
+        deltas = [p - b for b, p in pairs]
         mean_d = statistics.mean(deltas)
-        print(f"\n  baseline mean total : {statistics.mean(b_totals):.1f} turns")
-        print(f"  PEEK     mean total : {statistics.mean(p_totals):.1f} turns")
+        print(f"  paired questions    : {len(pairs)} of {attempted}"
+              + (f"  ({dropped} dropped to a CLI failure)" if dropped else ""))
+        print(f"  baseline mean turns : {statistics.mean(b for b, _ in pairs):.2f} per question")
+        print(f"  PEEK     mean turns : {statistics.mean(p for _, p in pairs):.2f} per question")
         if len(deltas) >= 2:
             sd = statistics.stdev(deltas)
-            print(f"  paired delta (PEEK - baseline): {mean_d:+.1f} +/- {sd:.1f} turns "
-                  f"(n={len(deltas)})")
+            print(f"  paired delta (PEEK - baseline): {mean_d:+.2f} turns per question "
+                  f"(SD {sd:.2f}, n={len(deltas)})")
+            # Deltas within one run are not fully independent -- the PEEK map
+            # evolves across the stream -- so this stays a descriptive
+            # mean-vs-spread read, not a significance test.
             verdict = (
-                "within run-to-run noise -- no measurable effect at this sample size"
+                "within question-to-question noise -- no measurable effect"
                 if abs(mean_d) <= sd
                 else ("PEEK faster" if mean_d < 0 else "PEEK slower")
             )
             print(f"  verdict: {verdict}")
         else:
-            print(f"  paired delta (PEEK - baseline): {mean_d:+.1f} turns "
-                  f"(n=1 -- not enough runs for a spread)")
+            print(f"  paired delta (PEEK - baseline): {mean_d:+.2f} turns per question "
+                  f"(n=1 -- not enough pairs for a spread)")
 
     total_q = len(questions) * runs
     b_correct = sum(ok for run in all_baseline for _, ok in run)

--- a/peek-experiments/experiment_3_rlm.py
+++ b/peek-experiments/experiment_3_rlm.py
@@ -1,0 +1,174 @@
+"""Experiment 3 -- PEEK end to end with a real RLM agent (the missing half).
+
+Experiments 1 and 2 exercise PEEK's machinery but feed it *canned* trajectories.
+This one closes the loop. A real RLM agent (``rlm_agent.RLMAgent``) actually
+explores a real ~71k-char long context (``corpus.build_corpus``) by running code
+in a REPL, and PEEK's ``CachePolicy`` distills each genuine trajectory into the
+context map.
+
+It answers the same question stream twice and compares:
+
+  * BASELINE -- every question answered with NO context map.
+  * PEEK     -- the map evolves across questions and is prepended to each run.
+
+Headline metric: model turns per question. PEEK should cut the orientation
+turns once the chapter index has been distilled into the map. Answers are
+checked against known facts so a turn saving is only meaningful if the agent
+still gets the answer right.
+
+Needs the `claude` CLI (a real model). This makes dozens of model calls.
+
+  python experiment_3_rlm.py                 # all 4 questions, both conditions
+  python experiment_3_rlm.py --questions 2   # shorter / cheaper smoke run
+  python experiment_3_rlm.py --model opus
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from peek import CachePolicy
+
+from claude_code_client import ClaudeCodeClient
+from corpus import build_corpus
+from rlm_agent import RLMAgent
+
+# Facts use deliberately non-standard values (19 weeks, 23 days, $685, 13) so
+# the agent cannot shortcut with a plausible guess -- it must read the corpus.
+QUESTIONS = [
+    {
+        "label": "parental leave (weeks)",
+        "q": "How many weeks of paid parental leave does ACME provide?",
+        "expect": "19",
+    },
+    {
+        "label": "vacation days at 5 yrs",
+        "q": "How many vacation days per year does an employee with 5 years of service receive?",
+        "expect": "23",
+    },
+    {
+        "label": "home-office setup stipend",
+        "q": "What is the dollar amount of the one-time home-office setup stipend?",
+        "expect": "685",
+    },
+    {
+        "label": "paid company holidays",
+        "q": "How many paid company holidays does ACME observe each year?",
+        "expect": "13",
+    },
+]
+
+TOKEN_BUDGET = 800
+
+
+def banner(text: str) -> None:
+    print("\n" + "=" * 78)
+    print(text)
+    print("=" * 78)
+
+
+def correct(answer: str, expect: str) -> bool:
+    return expect.lower() in answer.lower()
+
+
+def main(*, n_questions: int, model: str | None, max_iters: int) -> None:
+    questions = QUESTIONS[:n_questions]
+    corpus = build_corpus()
+
+    banner("EXPERIMENT 3 -- PEEK end to end with a real RLM agent")
+    print(f"corpus      : {len(corpus):,} chars, 9 chapters")
+    print(f"questions   : {len(questions)}")
+    print(f"agent model : {model or 'claude CLI default'}   max_iterations={max_iters}")
+
+    agent = RLMAgent(
+        ClaudeCodeClient(model=model),
+        max_iterations=max_iters,
+        verbose=True,
+    )
+
+    # ----- BASELINE: no context map, ever -----------------------------------
+    banner("CONDITION A -- BASELINE (no context map)")
+    baseline = []
+    for idx, item in enumerate(questions, start=1):
+        print(f"\n  Q{idx}: {item['q']}")
+        res = agent.run(question=item["q"], context=corpus, context_map="")
+        ok = correct(res.answer, item["expect"])
+        print(f"      -> {res.turns} turns, answer={res.answer[:80]!r}  [{'OK' if ok else 'WRONG'}]")
+        baseline.append((res, ok))
+
+    # ----- PEEK: the map evolves across the question stream -----------------
+    banner("CONDITION B -- PEEK (context map evolves across questions)")
+    policy = CachePolicy(
+        client=ClaudeCodeClient(model=model),
+        token_budget=TOKEN_BUDGET,
+        evolve_steps=None,  # evolve on every question
+    )
+    peek = []
+    for idx, item in enumerate(questions, start=1):
+        items_before = len(policy.cmap.items())
+        map_text = policy.current_map_text
+        print(f"\n  Q{idx}: {item['q']}")
+        print(f"      map in : {items_before} items, "
+              f"{policy.token_counter(map_text)} tokens")
+        res = agent.run(question=item["q"], context=corpus, context_map=map_text)
+        ok = correct(res.answer, item["expect"])
+        print(f"      -> {res.turns} turns, answer={res.answer[:80]!r}  [{'OK' if ok else 'WRONG'}]")
+        print("      distilling trajectory into the map (Distiller + Cartographer)...")
+        policy.update(trajectory=res.trajectory, question=item["q"])
+        peek.append((res, ok, items_before, len(policy.cmap.items())))
+
+    # ----- comparison -------------------------------------------------------
+    banner("RESULTS -- model turns per question (baseline vs PEEK)")
+    print(f"{'#':<3}{'question':<30}{'BASELINE':>18}{'PEEK':>18}{'map':>12}")
+    print(f"{'':<3}{'':<30}{'turns  answer':>18}{'turns  answer':>18}{'items':>12}")
+    print("-" * 81)
+    b_turns = p_turns = 0
+    for idx, item in enumerate(questions):
+        (b_res, b_ok) = baseline[idx]
+        (p_res, p_ok, m_before, m_after) = peek[idx]
+        b_turns += b_res.turns
+        p_turns += p_res.turns
+        print(
+            f"{idx + 1:<3}{item['label']:<30}"
+            f"{b_res.turns:>6}  {'ok' if b_ok else 'WRONG':<9}"
+            f"{p_res.turns:>6}  {'ok' if p_ok else 'WRONG':<9}"
+            f"{m_before:>5}->{m_after:<5}"
+        )
+    print("-" * 81)
+    print(f"{'':<3}{'TOTAL turns':<30}{b_turns:>6}{'':<11}{p_turns:>6}")
+    if b_turns:
+        delta = b_turns - p_turns
+        pct = 100.0 * delta / b_turns
+        print(f"\n  PEEK used {p_turns} turns vs baseline {b_turns} "
+              f"-- {delta:+d} turns ({pct:+.0f}%).")
+    b_correct = sum(ok for _, ok in baseline)
+    p_correct = sum(ok for _, ok, _, _ in peek)
+    print(f"  Answers correct: baseline {b_correct}/{len(questions)}, "
+          f"PEEK {p_correct}/{len(questions)}.")
+
+    banner("FINAL CONTEXT MAP (distilled from the real trajectories)")
+    print(policy.current_map_text.rstrip())
+
+    policy.save("output/acme-handbook-rlm.peek.json")
+    print("\nsaved evolved map -> output/acme-handbook-rlm.peek.json")
+    print(
+        "\nNote: Q1 sees an empty map (nothing cached yet), so it is the fair "
+        "baseline\nfor the PEEK column; the gain, if any, shows up on Q2+ once "
+        "the chapter\nindex and section pointers have been distilled in."
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--questions", type=int, default=len(QUESTIONS),
+                        help="how many questions from the stream to run")
+    parser.add_argument("--model", default=None,
+                        help="model alias/name for the `claude` CLI (e.g. 'opus')")
+    parser.add_argument("--max-iters", type=int, default=8,
+                        help="max REPL turns per question before giving up")
+    args = parser.parse_args()
+    main(
+        n_questions=max(1, min(args.questions, len(QUESTIONS))),
+        model=args.model,
+        max_iters=args.max_iters,
+    )

--- a/peek-experiments/experiment_3_rlm.py
+++ b/peek-experiments/experiment_3_rlm.py
@@ -1,31 +1,32 @@
-"""Experiment 3 -- PEEK end to end with a real RLM agent (the missing half).
+"""Experiment 3 -- PEEK end to end with a real RLM agent, measured over N runs.
 
-Experiments 1 and 2 exercise PEEK's machinery but feed it *canned* trajectories.
-This one closes the loop. A real RLM agent (``rlm_agent.RLMAgent``) actually
-explores a real ~71k-char long context (``corpus.build_corpus``) by running code
-in a REPL, and PEEK's ``CachePolicy`` distills each genuine trajectory into the
-context map.
+Experiments 1 and 2 exercise PEEK's machinery on *canned* trajectories. This
+one closes the loop: a real RLM agent (``rlm_agent.RLMAgent``) actually explores
+a real ~72k-char long context (``corpus.build_corpus``) by running code in a
+REPL, and PEEK's ``CachePolicy`` distills each genuine trajectory into the map.
 
-It answers the same question stream twice and compares:
+Each run answers the same question stream twice:
 
   * BASELINE -- every question answered with NO context map.
   * PEEK     -- the map evolves across questions and is prepended to each run.
 
-Headline metric: model turns per question. PEEK should cut the orientation
-turns once the chapter index has been distilled into the map. Answers are
-checked against known facts so a turn saving is only meaningful if the agent
-still gets the answer right.
+Because a real model is non-deterministic, a single run is just noise. This
+script repeats the whole baseline/PEEK comparison ``--runs`` times and reports
+per-question means and a paired (PEEK - baseline) total delta with its spread,
+so the comparison is something you can actually read a signal off of (n
+permitting).
 
-Needs the `claude` CLI (a real model). This makes dozens of model calls.
+Needs the `claude` CLI. This makes a LOT of model calls -- roughly 33 per run.
 
-  python experiment_3_rlm.py                 # all 4 questions, both conditions
-  python experiment_3_rlm.py --questions 2   # shorter / cheaper smoke run
-  python experiment_3_rlm.py --model opus
+  python experiment_3_rlm.py                    # 3 runs, 4 questions
+  python experiment_3_rlm.py --runs 5           # more runs = tighter estimate
+  python experiment_3_rlm.py --runs 1 --questions 2   # quick smoke check
 """
 
 from __future__ import annotations
 
 import argparse
+import statistics
 
 from peek import CachePolicy
 
@@ -73,117 +74,152 @@ def correct(answer: str, expect: str) -> bool:
 
 def safe_run(agent: RLMAgent, question: str, context: str, context_map: str) -> RLMResult:
     """Run the agent, turning a persistent CLI failure into a sentinel result
-    so one flaky call cannot abort the whole comparison."""
+    so one flaky call cannot abort the whole multi-run comparison."""
     try:
         return agent.run(question=question, context=context, context_map=context_map)
     except ClaudeCodeError as e:
-        print(f"      !! agent run failed after retries: {e}")
+        print(f"        !! agent run failed after retries: {e}")
         return RLMResult(answer="(failed)", trajectory="", iterations=0,
                          turns=0, stopped="error")
 
 
-def main(*, n_questions: int, model: str | None, max_iters: int) -> None:
+def one_pass(
+    agent: RLMAgent,
+    questions: list[dict],
+    corpus: str,
+    policy: CachePolicy | None,
+    *,
+    tag: str,
+) -> list[tuple[RLMResult, bool]]:
+    """One sweep over every question. ``policy=None`` is the baseline (no map);
+    otherwise the map is prepended and updated from each trajectory."""
+    rows: list[tuple[RLMResult, bool]] = []
+    for idx, item in enumerate(questions, start=1):
+        map_text = policy.current_map_text if policy is not None else ""
+        map_note = f" (map: {len(policy.cmap.items())} items)" if policy is not None else ""
+        print(f"    {tag} Q{idx}{map_note}")
+        res = safe_run(agent, item["q"], corpus, map_text)
+        ok = correct(res.answer, item["expect"])
+        flag = "FAILED" if res.stopped == "error" else ("ok" if ok else "WRONG")
+        print(f"        -> {res.turns} turns [{flag}]  answer={res.answer[:60]!r}")
+        if policy is not None and res.stopped != "error" and res.trajectory:
+            try:
+                policy.update(trajectory=res.trajectory, question=item["q"])
+            except ClaudeCodeError as e:
+                print(f"        !! distillation failed after retries: {e}")
+        rows.append((res, ok))
+    return rows
+
+
+def _fmt(values: list[int]) -> str:
+    """mean and range of a list of turn counts, for the aggregate table."""
+    if not values:
+        return "n/a"
+    mean = statistics.mean(values)
+    if min(values) == max(values):
+        return f"{mean:>4.1f}  ({min(values)})"
+    return f"{mean:>4.1f}  ({min(values)}-{max(values)})"
+
+
+def main(*, n_questions: int, runs: int, model: str | None, max_iters: int) -> None:
     questions = QUESTIONS[:n_questions]
     corpus = build_corpus()
 
     banner("EXPERIMENT 3 -- PEEK end to end with a real RLM agent")
     print(f"corpus      : {len(corpus):,} chars, 9 chapters")
-    print(f"questions   : {len(questions)}")
+    print(f"questions   : {len(questions)}   runs: {runs}")
     print(f"agent model : {model or 'claude CLI default'}   max_iterations={max_iters}")
 
-    agent = RLMAgent(
-        ClaudeCodeClient(model=model),
-        max_iterations=max_iters,
-        verbose=True,
-    )
+    agent_client = ClaudeCodeClient(model=model)
+    peek_client = ClaudeCodeClient(model=model)
+    agent = RLMAgent(agent_client, max_iterations=max_iters, verbose=True)
 
-    # ----- BASELINE: no context map, ever -----------------------------------
-    banner("CONDITION A -- BASELINE (no context map)")
-    baseline = []
-    for idx, item in enumerate(questions, start=1):
-        print(f"\n  Q{idx}: {item['q']}")
-        res = safe_run(agent, item["q"], corpus, context_map="")
-        ok = correct(res.answer, item["expect"])
-        print(f"      -> {res.turns} turns, answer={res.answer[:80]!r}  [{'OK' if ok else 'WRONG'}]")
-        baseline.append((res, ok))
+    # all_baseline[run][question] = (RLMResult, ok); same shape for all_peek.
+    all_baseline: list[list[tuple[RLMResult, bool]]] = []
+    all_peek: list[list[tuple[RLMResult, bool]]] = []
+    last_policy: CachePolicy | None = None
 
-    # ----- PEEK: the map evolves across the question stream -----------------
-    banner("CONDITION B -- PEEK (context map evolves across questions)")
-    policy = CachePolicy(
-        client=ClaudeCodeClient(model=model),
-        token_budget=TOKEN_BUDGET,
-        evolve_steps=None,  # evolve on every question
-    )
-    peek = []
-    for idx, item in enumerate(questions, start=1):
-        items_before = len(policy.cmap.items())
-        map_text = policy.current_map_text
-        print(f"\n  Q{idx}: {item['q']}")
-        print(f"      map in : {items_before} items, "
-              f"{policy.token_counter(map_text)} tokens")
-        res = safe_run(agent, item["q"], corpus, context_map=map_text)
-        ok = correct(res.answer, item["expect"])
-        print(f"      -> {res.turns} turns, answer={res.answer[:80]!r}  [{'OK' if ok else 'WRONG'}]")
-        if res.stopped != "error" and res.trajectory:
-            print("      distilling trajectory into the map (Distiller + Cartographer)...")
-            try:
-                policy.update(trajectory=res.trajectory, question=item["q"])
-            except ClaudeCodeError as e:
-                print(f"      !! distillation failed after retries: {e}")
-        peek.append((res, ok, items_before, len(policy.cmap.items())))
+    for r in range(1, runs + 1):
+        banner(f"RUN {r}/{runs}")
+        print("  condition A -- baseline (no context map)")
+        all_baseline.append(one_pass(agent, questions, corpus, None, tag="base"))
 
-    # ----- comparison -------------------------------------------------------
-    banner("RESULTS -- model turns per question (baseline vs PEEK)")
-    print(f"{'#':<3}{'question':<30}{'BASELINE':>18}{'PEEK':>18}{'map':>12}")
-    print(f"{'':<3}{'':<30}{'turns  answer':>18}{'turns  answer':>18}{'items':>12}")
-    print("-" * 81)
-    b_turns = p_turns = comparable = 0
-    for idx, item in enumerate(questions):
-        (b_res, b_ok) = baseline[idx]
-        (p_res, p_ok, m_before, m_after) = peek[idx]
-        both_ran = b_res.stopped != "error" and p_res.stopped != "error"
-        if both_ran:
-            b_turns += b_res.turns
-            p_turns += p_res.turns
-            comparable += 1
-        b_cell = "n/a" if b_res.stopped == "error" else str(b_res.turns)
-        p_cell = "n/a" if p_res.stopped == "error" else str(p_res.turns)
-        print(
-            f"{idx + 1:<3}{item['label']:<30}"
-            f"{b_cell:>6}  {'ok' if b_ok else 'WRONG':<9}"
-            f"{p_cell:>6}  {'ok' if p_ok else 'WRONG':<9}"
-            f"{m_before:>5}->{m_after:<5}"
+        print("\n  condition B -- PEEK (map evolves across the question stream)")
+        policy = CachePolicy(
+            client=peek_client, token_budget=TOKEN_BUDGET, evolve_steps=None
         )
-    print("-" * 81)
-    if comparable:
-        print(f"{'':<3}{'TOTAL turns (' + str(comparable) + ' comparable Qs)':<30}"
-              f"{b_turns:>6}{'':<11}{p_turns:>6}")
-        delta = b_turns - p_turns
-        pct = 100.0 * delta / b_turns if b_turns else 0.0
-        print(f"\n  PEEK used {p_turns} turns vs baseline {b_turns} "
-              f"-- {delta:+d} turns ({pct:+.0f}%) over {comparable} question(s) "
-              "that completed in both conditions.")
+        all_peek.append(one_pass(agent, questions, corpus, policy, tag="peek"))
+        last_policy = policy
+
+    # ---- aggregate ---------------------------------------------------------
+    banner(f"AGGREGATE -- model turns per question, averaged over {runs} run(s)")
+    print(f"{'#':<3}{'question':<28}{'BASELINE':>18}{'PEEK':>18}")
+    print(f"{'':<31}{'mean  (range)':>18}{'mean  (range)':>18}")
+    print("-" * 67)
+    for i, item in enumerate(questions):
+        b = [all_baseline[r][i][0].turns for r in range(runs)
+             if all_baseline[r][i][0].stopped != "error"]
+        p = [all_peek[r][i][0].turns for r in range(runs)
+             if all_peek[r][i][0].stopped != "error"]
+        print(f"{i + 1:<3}{item['label']:<28}{_fmt(b):>18}{_fmt(p):>18}")
+    print("-" * 67)
+
+    # Paired per-run totals -- only runs where every question completed in
+    # both conditions are comparable.
+    deltas: list[int] = []
+    b_totals: list[int] = []
+    p_totals: list[int] = []
+    for r in range(runs):
+        b_ok = all(res.stopped != "error" for res, _ in all_baseline[r])
+        p_ok = all(res.stopped != "error" for res, _ in all_peek[r])
+        if b_ok and p_ok:
+            bt = sum(res.turns for res, _ in all_baseline[r])
+            pt = sum(res.turns for res, _ in all_peek[r])
+            b_totals.append(bt)
+            p_totals.append(pt)
+            deltas.append(pt - bt)
+
+    banner("PAIRED COMPARISON -- total turns per run (PEEK vs baseline)")
+    if not deltas:
+        print("  No run completed every question in both conditions -- cannot compare.")
     else:
-        print("  No question completed in both conditions -- nothing to compare.")
-    b_correct = sum(ok for _, ok in baseline)
-    p_correct = sum(ok for _, ok, _, _ in peek)
-    print(f"  Answers correct: baseline {b_correct}/{len(questions)}, "
-          f"PEEK {p_correct}/{len(questions)}.")
+        for idx, (bt, pt) in enumerate(zip(b_totals, p_totals), start=1):
+            print(f"  run {idx}: baseline {bt:>3}  |  PEEK {pt:>3}  |  delta {pt - bt:+d}")
+        mean_d = statistics.mean(deltas)
+        print(f"\n  baseline mean total : {statistics.mean(b_totals):.1f} turns")
+        print(f"  PEEK     mean total : {statistics.mean(p_totals):.1f} turns")
+        if len(deltas) >= 2:
+            sd = statistics.stdev(deltas)
+            print(f"  paired delta (PEEK - baseline): {mean_d:+.1f} +/- {sd:.1f} turns "
+                  f"(n={len(deltas)})")
+            verdict = (
+                "within run-to-run noise -- no measurable effect at this sample size"
+                if abs(mean_d) <= sd
+                else ("PEEK faster" if mean_d < 0 else "PEEK slower")
+            )
+            print(f"  verdict: {verdict}")
+        else:
+            print(f"  paired delta (PEEK - baseline): {mean_d:+.1f} turns "
+                  f"(n=1 -- not enough runs for a spread)")
 
-    banner("FINAL CONTEXT MAP (distilled from the real trajectories)")
-    print(policy.current_map_text.rstrip())
+    total_q = len(questions) * runs
+    b_correct = sum(ok for run in all_baseline for _, ok in run)
+    p_correct = sum(ok for run in all_peek for _, ok in run)
+    print(f"\n  answers correct: baseline {b_correct}/{total_q}, PEEK {p_correct}/{total_q}")
+    print(f"  total model calls: agent {agent_client.calls}, "
+          f"PEEK Distiller/Cartographer {peek_client.calls}")
 
-    policy.save("output/acme-handbook-rlm.peek.json")
-    print("\nsaved evolved map -> output/acme-handbook-rlm.peek.json")
-    print(
-        "\nNote: Q1 sees an empty map (nothing cached yet), so it is the fair "
-        "baseline\nfor the PEEK column; the gain, if any, shows up on Q2+ once "
-        "the chapter\nindex and section pointers have been distilled in."
-    )
+    if last_policy is not None:
+        banner("FINAL CONTEXT MAP (from the last run's evolved map)")
+        print(last_policy.current_map_text.rstrip())
+        last_policy.save("output/acme-handbook-rlm.peek.json")
+        print("\nsaved last-run map -> output/acme-handbook-rlm.peek.json")
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--runs", type=int, default=3,
+                        help="how many times to repeat the baseline/PEEK comparison")
     parser.add_argument("--questions", type=int, default=len(QUESTIONS),
                         help="how many questions from the stream to run")
     parser.add_argument("--model", default=None,
@@ -193,6 +229,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     main(
         n_questions=max(1, min(args.questions, len(QUESTIONS))),
+        runs=max(1, args.runs),
         model=args.model,
         max_iters=args.max_iters,
     )

--- a/peek-experiments/experiment_3_rlm.py
+++ b/peek-experiments/experiment_3_rlm.py
@@ -29,9 +29,9 @@ import argparse
 
 from peek import CachePolicy
 
-from claude_code_client import ClaudeCodeClient
+from claude_code_client import ClaudeCodeClient, ClaudeCodeError
 from corpus import build_corpus
-from rlm_agent import RLMAgent
+from rlm_agent import RLMAgent, RLMResult
 
 # Facts use deliberately non-standard values (19 weeks, 23 days, $685, 13) so
 # the agent cannot shortcut with a plausible guess -- it must read the corpus.
@@ -71,6 +71,17 @@ def correct(answer: str, expect: str) -> bool:
     return expect.lower() in answer.lower()
 
 
+def safe_run(agent: RLMAgent, question: str, context: str, context_map: str) -> RLMResult:
+    """Run the agent, turning a persistent CLI failure into a sentinel result
+    so one flaky call cannot abort the whole comparison."""
+    try:
+        return agent.run(question=question, context=context, context_map=context_map)
+    except ClaudeCodeError as e:
+        print(f"      !! agent run failed after retries: {e}")
+        return RLMResult(answer="(failed)", trajectory="", iterations=0,
+                         turns=0, stopped="error")
+
+
 def main(*, n_questions: int, model: str | None, max_iters: int) -> None:
     questions = QUESTIONS[:n_questions]
     corpus = build_corpus()
@@ -91,7 +102,7 @@ def main(*, n_questions: int, model: str | None, max_iters: int) -> None:
     baseline = []
     for idx, item in enumerate(questions, start=1):
         print(f"\n  Q{idx}: {item['q']}")
-        res = agent.run(question=item["q"], context=corpus, context_map="")
+        res = safe_run(agent, item["q"], corpus, context_map="")
         ok = correct(res.answer, item["expect"])
         print(f"      -> {res.turns} turns, answer={res.answer[:80]!r}  [{'OK' if ok else 'WRONG'}]")
         baseline.append((res, ok))
@@ -110,11 +121,15 @@ def main(*, n_questions: int, model: str | None, max_iters: int) -> None:
         print(f"\n  Q{idx}: {item['q']}")
         print(f"      map in : {items_before} items, "
               f"{policy.token_counter(map_text)} tokens")
-        res = agent.run(question=item["q"], context=corpus, context_map=map_text)
+        res = safe_run(agent, item["q"], corpus, context_map=map_text)
         ok = correct(res.answer, item["expect"])
         print(f"      -> {res.turns} turns, answer={res.answer[:80]!r}  [{'OK' if ok else 'WRONG'}]")
-        print("      distilling trajectory into the map (Distiller + Cartographer)...")
-        policy.update(trajectory=res.trajectory, question=item["q"])
+        if res.stopped != "error" and res.trajectory:
+            print("      distilling trajectory into the map (Distiller + Cartographer)...")
+            try:
+                policy.update(trajectory=res.trajectory, question=item["q"])
+            except ClaudeCodeError as e:
+                print(f"      !! distillation failed after retries: {e}")
         peek.append((res, ok, items_before, len(policy.cmap.items())))
 
     # ----- comparison -------------------------------------------------------
@@ -122,25 +137,34 @@ def main(*, n_questions: int, model: str | None, max_iters: int) -> None:
     print(f"{'#':<3}{'question':<30}{'BASELINE':>18}{'PEEK':>18}{'map':>12}")
     print(f"{'':<3}{'':<30}{'turns  answer':>18}{'turns  answer':>18}{'items':>12}")
     print("-" * 81)
-    b_turns = p_turns = 0
+    b_turns = p_turns = comparable = 0
     for idx, item in enumerate(questions):
         (b_res, b_ok) = baseline[idx]
         (p_res, p_ok, m_before, m_after) = peek[idx]
-        b_turns += b_res.turns
-        p_turns += p_res.turns
+        both_ran = b_res.stopped != "error" and p_res.stopped != "error"
+        if both_ran:
+            b_turns += b_res.turns
+            p_turns += p_res.turns
+            comparable += 1
+        b_cell = "n/a" if b_res.stopped == "error" else str(b_res.turns)
+        p_cell = "n/a" if p_res.stopped == "error" else str(p_res.turns)
         print(
             f"{idx + 1:<3}{item['label']:<30}"
-            f"{b_res.turns:>6}  {'ok' if b_ok else 'WRONG':<9}"
-            f"{p_res.turns:>6}  {'ok' if p_ok else 'WRONG':<9}"
+            f"{b_cell:>6}  {'ok' if b_ok else 'WRONG':<9}"
+            f"{p_cell:>6}  {'ok' if p_ok else 'WRONG':<9}"
             f"{m_before:>5}->{m_after:<5}"
         )
     print("-" * 81)
-    print(f"{'':<3}{'TOTAL turns':<30}{b_turns:>6}{'':<11}{p_turns:>6}")
-    if b_turns:
+    if comparable:
+        print(f"{'':<3}{'TOTAL turns (' + str(comparable) + ' comparable Qs)':<30}"
+              f"{b_turns:>6}{'':<11}{p_turns:>6}")
         delta = b_turns - p_turns
-        pct = 100.0 * delta / b_turns
+        pct = 100.0 * delta / b_turns if b_turns else 0.0
         print(f"\n  PEEK used {p_turns} turns vs baseline {b_turns} "
-              f"-- {delta:+d} turns ({pct:+.0f}%).")
+              f"-- {delta:+d} turns ({pct:+.0f}%) over {comparable} question(s) "
+              "that completed in both conditions.")
+    else:
+        print("  No question completed in both conditions -- nothing to compare.")
     b_correct = sum(ok for _, ok in baseline)
     p_correct = sum(ok for _, ok, _, _ in peek)
     print(f"  Answers correct: baseline {b_correct}/{len(questions)}, "

--- a/peek-experiments/experiment_3_rlm.py
+++ b/peek-experiments/experiment_3_rlm.py
@@ -16,7 +16,8 @@ per-question means and a paired (PEEK - baseline) total delta with its spread,
 so the comparison is something you can actually read a signal off of (n
 permitting).
 
-Needs the `claude` CLI. This makes a LOT of model calls -- well over 100 per run.
+Needs the `claude` CLI. This makes a LOT of model calls -- on the order of
+80-100 per run (8 questions x both conditions, plus PEEK's two calls per step).
 
   python experiment_3_rlm.py                    # 3 runs, 8 questions
   python experiment_3_rlm.py --runs 5           # more runs = tighter estimate

--- a/peek-experiments/requirements.txt
+++ b/peek-experiments/requirements.txt
@@ -1,0 +1,6 @@
+# PEEK ("peek-ai") is not on PyPI yet -- install it straight from the repo.
+# This pulls in tiktoken (the default token counter) transitively.
+peek-ai @ git+https://github.com/zhuohangu/peek.git
+
+# Optional: only needed to run PEEK's own unit test suite.
+pytest>=8.0.0

--- a/peek-experiments/rlm_agent.py
+++ b/peek-experiments/rlm_agent.py
@@ -1,0 +1,174 @@
+"""A minimal but real RLM (Recursive Language Model) agent.
+
+This is the half that experiments 1 and 2 faked. The agent answers a question
+about a long CONTEXT that is too large to read directly: the context lives in a
+Python REPL as a variable, and the model explores it by emitting code blocks,
+reading the (truncated) output, and iterating until it emits ``FINAL:``.
+
+It produces a genuine trajectory string -- exactly the kind PEEK's Distiller
+prompt is written for -- which the caller hands to ``CachePolicy.update``.
+
+WARNING: this executes model-generated Python. It is intended only for the
+ephemeral sandbox these experiments run in. Each exec is wrapped in a wall-clock
+alarm, but that is a guard rail, not real isolation.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import re
+import signal
+import traceback
+from dataclasses import dataclass
+
+from peek.llm.base import LMClient
+
+_CODE_BLOCK = re.compile(r"```(?:python)?\s*(.*?)```", re.DOTALL | re.IGNORECASE)
+_FINAL = re.compile(r"FINAL:\s*(.*)", re.DOTALL)
+
+
+@dataclass
+class RLMResult:
+    answer: str
+    trajectory: str
+    iterations: int          # number of REPL code-exec turns
+    turns: int               # number of model calls (the cost metric)
+    stopped: str             # "final" | "max_iters"
+
+
+class _ExecTimeout(Exception):
+    pass
+
+
+def _run_code(code: str, namespace: dict, timeout_s: int) -> str:
+    """Exec ``code``, returning captured stdout (or a traceback)."""
+
+    def _alarm(signum, frame):  # noqa: ANN001
+        raise _ExecTimeout()
+
+    buf = io.StringIO()
+    old = signal.signal(signal.SIGALRM, _alarm)
+    signal.alarm(timeout_s)
+    try:
+        with contextlib.redirect_stdout(buf):
+            exec(code, namespace)  # noqa: S102 -- intentional: this is an RLM
+    except _ExecTimeout:
+        buf.write(f"\n[execution aborted: exceeded {timeout_s}s]")
+    except Exception:  # noqa: BLE001 -- feed the error back to the model
+        buf.write("\n" + traceback.format_exc())
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, old)
+    return buf.getvalue()
+
+
+class RLMAgent:
+    """Drives one question to an answer via an LM + a persistent Python REPL."""
+
+    def __init__(
+        self,
+        client: LMClient,
+        *,
+        max_iterations: int = 8,
+        output_limit: int = 1400,
+        exec_timeout_s: int = 10,
+        verbose: bool = False,
+    ) -> None:
+        self.client = client
+        self.max_iterations = max_iterations
+        self.output_limit = output_limit
+        self.exec_timeout_s = exec_timeout_s
+        self.verbose = verbose
+
+    def _system(self, question: str, n_chars: int, context_map: str) -> str:
+        map_block = ""
+        if context_map.strip():
+            map_block = (
+                "\nYou also have a CONTEXT MAP: orientation knowledge cached from "
+                "earlier tasks on this SAME context. Trust it to navigate faster "
+                "instead of rediscovering structure.\n"
+                "<<<CONTEXT MAP>>>\n"
+                f"{context_map.strip()}\n"
+                "<<<END CONTEXT MAP>>>\n"
+            )
+        return (
+            "You are an autonomous research agent. Answer the QUESTION about a "
+            "large document called CONTEXT.\n\n"
+            f"CONTEXT is too large to read in full ({n_chars:,} characters). It is "
+            "preloaded in a Python REPL as the string variable `context`. The REPL "
+            "state PERSISTS between your turns: variables you assign stay available.\n"
+            f"{map_block}\n"
+            "HOW TO WORK:\n"
+            "- Each turn, reply with EXACTLY ONE Python code block, e.g.:\n"
+            "  ```python\n"
+            "  i = context.find('=== CHAPTER 7')\n"
+            "  print(i, context[i:i+300])\n"
+            "  ```\n"
+            "- Whatever you print() is run and returned to you, truncated to "
+            f"{self.output_limit} characters.\n"
+            "- Explore by searching/slicing `context` (you may `import re`). "
+            "NEVER print the whole `context`.\n"
+            "- This is ACME's own handbook; its specific figures may differ from "
+            "typical real-world policy. You MUST locate the answer inside "
+            "`context` and verify it before answering -- never answer from prior "
+            "knowledge, memory, or assumption.\n"
+            "- When you have verified the answer in `context`, reply with NO code "
+            "block and a single line:\n"
+            "  FINAL: <your answer>\n"
+            "- Be efficient: use as few turns as possible.\n\n"
+            f"QUESTION: {question}\n"
+        )
+
+    def _truncate(self, text: str) -> str:
+        if len(text) <= self.output_limit:
+            return text
+        return text[: self.output_limit] + "\n...[output truncated]"
+
+    def run(self, *, question: str, context: str, context_map: str = "") -> RLMResult:
+        namespace: dict = {"context": context}
+        system = self._system(question, len(context), context_map)
+        transcript: list[str] = []
+        turns = 0
+
+        for i in range(1, self.max_iterations + 1):
+            prompt = system
+            if transcript:
+                prompt += "\n" + "\n".join(transcript)
+            prompt += f"\n\n[Turn {i}] Your move:"
+
+            reply = self.client.completion([{"role": "user", "content": prompt}]) or ""
+            turns += 1
+
+            code_match = _CODE_BLOCK.search(reply)
+            if not code_match:
+                # No code block => this turn is the final answer.
+                final = _FINAL.search(reply)
+                answer = (final.group(1) if final else reply).strip()
+                if self.verbose:
+                    print(f"      turn {i}: FINAL")
+                transcript.append(f"[FINAL]\n{answer}")
+                return RLMResult(
+                    answer=answer,
+                    trajectory=f"QUESTION: {question}\n\n" + "\n\n".join(transcript),
+                    iterations=i - 1,
+                    turns=turns,
+                    stopped="final",
+                )
+
+            code = code_match.group(1).strip()
+            output = self._truncate(_run_code(code, namespace, self.exec_timeout_s))
+            if self.verbose:
+                first = code.splitlines()[0] if code.splitlines() else ""
+                print(f"      turn {i}: exec  | {first[:70]}")
+            transcript.append(
+                f"[Turn {i}]\nCODE:\n{code}\nREPL OUTPUT:\n{output}"
+            )
+
+        return RLMResult(
+            answer="(no answer - hit max iterations)",
+            trajectory=f"QUESTION: {question}\n\n" + "\n\n".join(transcript),
+            iterations=self.max_iterations,
+            turns=turns,
+            stopped="max_iters",
+        )

--- a/peek-experiments/rlm_agent.py
+++ b/peek-experiments/rlm_agent.py
@@ -86,8 +86,10 @@ class RLMAgent:
         if context_map.strip():
             map_block = (
                 "\nYou also have a CONTEXT MAP: orientation knowledge cached from "
-                "earlier tasks on this SAME context. Trust it to navigate faster "
-                "instead of rediscovering structure.\n"
+                "earlier tasks on this SAME context. Use it to jump straight to the "
+                "right region instead of rediscovering structure. The map is a "
+                "navigation aid only -- it may be incomplete or mistaken, so always "
+                "confirm the actual answer by reading `context` itself.\n"
                 "<<<CONTEXT MAP>>>\n"
                 f"{context_map.strip()}\n"
                 "<<<END CONTEXT MAP>>>\n"
@@ -113,8 +115,10 @@ class RLMAgent:
             "typical real-world policy. You MUST locate the answer inside "
             "`context` and verify it before answering -- never answer from prior "
             "knowledge, memory, or assumption.\n"
-            "- When you have verified the answer in `context`, reply with NO code "
-            "block and a single line:\n"
+            "- You MUST run at least one code block and see real REPL output from "
+            "`context` before you may answer. Never emit FINAL on your first turn.\n"
+            "- When (and only when) you have verified the answer in `context`, "
+            "reply with NO code block and a single line:\n"
             "  FINAL: <your answer>\n"
             "- Be efficient: use as few turns as possible.\n\n"
             f"QUESTION: {question}\n"
@@ -130,6 +134,17 @@ class RLMAgent:
         system = self._system(question, len(context), context_map)
         transcript: list[str] = []
         turns = 0
+        execs = 0      # code blocks actually run against `context`
+        nudges = 0     # premature-FINAL rejections (capped, to avoid a loop)
+
+        def _result(answer: str, stopped: str) -> RLMResult:
+            return RLMResult(
+                answer=answer,
+                trajectory=f"QUESTION: {question}\n\n" + "\n\n".join(transcript),
+                iterations=execs,
+                turns=turns,
+                stopped=stopped,
+            )
 
         for i in range(1, self.max_iterations + 1):
             prompt = system
@@ -142,33 +157,33 @@ class RLMAgent:
 
             code_match = _CODE_BLOCK.search(reply)
             if not code_match:
-                # No code block => this turn is the final answer.
                 final = _FINAL.search(reply)
                 answer = (final.group(1) if final else reply).strip()
+                # An RLM must read its external context. Reject an answer given
+                # before any search -- otherwise the model just guesses (and a
+                # prepended context map makes that far more tempting).
+                if execs == 0 and nudges < 2:
+                    nudges += 1
+                    if self.verbose:
+                        print(f"      turn {i}: premature FINAL rejected (no search yet)")
+                    transcript.append(
+                        f"[Turn {i}] You answered without running any code:\n{answer}\n"
+                        "REJECTED: you have not inspected `context` yet. Run at least "
+                        "one code block that searches `context` and base your answer "
+                        "strictly on the real output."
+                    )
+                    continue
                 if self.verbose:
                     print(f"      turn {i}: FINAL")
                 transcript.append(f"[FINAL]\n{answer}")
-                return RLMResult(
-                    answer=answer,
-                    trajectory=f"QUESTION: {question}\n\n" + "\n\n".join(transcript),
-                    iterations=i - 1,
-                    turns=turns,
-                    stopped="final",
-                )
+                return _result(answer, "final")
 
             code = code_match.group(1).strip()
             output = self._truncate(_run_code(code, namespace, self.exec_timeout_s))
+            execs += 1
             if self.verbose:
                 first = code.splitlines()[0] if code.splitlines() else ""
                 print(f"      turn {i}: exec  | {first[:70]}")
-            transcript.append(
-                f"[Turn {i}]\nCODE:\n{code}\nREPL OUTPUT:\n{output}"
-            )
+            transcript.append(f"[Turn {i}]\nCODE:\n{code}\nREPL OUTPUT:\n{output}")
 
-        return RLMResult(
-            answer="(no answer - hit max iterations)",
-            trajectory=f"QUESTION: {question}\n\n" + "\n\n".join(transcript),
-            iterations=self.max_iterations,
-            turns=turns,
-            stopped="max_iters",
-        )
+        return _result("(no answer - hit max iterations)", "max_iters")

--- a/peek-experiments/scripted_client.py
+++ b/peek-experiments/scripted_client.py
@@ -1,0 +1,99 @@
+"""A scripted, offline LM client for driving PEEK without an API key.
+
+PEEK's ``CachePolicy.update`` makes two LM calls per step: first the Distiller,
+then the Cartographer. Each call is a single user message whose prompt embeds
+the current context map. This client routes each call by inspecting the prompt
+and returns pre-programmed JSON, so the *real* PEEK control flow (context-map
+edits, scoring, the priority Evictor, and freezing) runs end to end and
+deterministically. The README of the `peek` repo explicitly endorses "a local
+stub" as a valid `LMClient`.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Callable
+
+from peek.core.types import Usage
+
+# Distinct first-line markers from peek/prompts/{distiller,cartographer}.txt.
+_CARTOGRAPHER_MARKER = "context map curator"
+
+# Map items render as a single line: "[<slug>-NNNNN] <content>".
+_ITEM_LINE = re.compile(r"\[([a-z]{2,4}-\d{5})\]\s*(.*)")
+
+Response = dict | Callable[[str], dict]
+
+_EMPTY_DISTILLER: dict = {"diagnosis": "", "item_tags": {}, "cache_candidates": []}
+_EMPTY_CARTOGRAPHER: dict = {"reasoning": "no edits", "operations": []}
+
+
+def map_ids(prompt: str) -> list[str]:
+    """Ordered item IDs found in the context map embedded in a prompt."""
+    return [m.group(1) for m in _ITEM_LINE.finditer(prompt)]
+
+
+def id_of(prompt: str, needle: str) -> str | None:
+    """ID of the first map item whose content contains ``needle``."""
+    for m in _ITEM_LINE.finditer(prompt):
+        if needle in m.group(2):
+            return m.group(1)
+    return None
+
+
+def tags_for(prompt: str, rules: list[tuple[str, str]]) -> dict[str, str]:
+    """Build an ``item_tags`` dict by matching content needles to tags."""
+    tags: dict[str, str] = {}
+    for needle, tag in rules:
+        item_id = id_of(prompt, needle)
+        if item_id is not None:
+            tags[item_id] = tag
+    return tags
+
+
+class ScriptedLMClient:
+    """An ``LMClient`` that replays pre-programmed Distiller/Cartographer JSON.
+
+    Parameters
+    ----------
+    distiller_script, cartographer_script:
+        Ordered responses. Each entry is either a ``dict`` (used as-is) or a
+        ``callable`` that receives the prompt text and returns a ``dict`` --
+        the callable form lets a response reference live, freshly-minted
+        item IDs that are only known at run time.
+    """
+
+    def __init__(
+        self,
+        distiller_script: list[Response],
+        cartographer_script: list[Response],
+    ) -> None:
+        self._distiller = list(distiller_script)
+        self._cartographer = list(cartographer_script)
+        self.transcript: list[tuple[str, dict]] = []
+        self.calls = 0
+        self._last = Usage()
+
+    def completion(self, messages: list[dict]) -> str:
+        prompt = messages[-1]["content"]
+        is_cartographer = _CARTOGRAPHER_MARKER in prompt
+        role = "cartographer" if is_cartographer else "distiller"
+        queue = self._cartographer if is_cartographer else self._distiller
+
+        if queue:
+            entry = queue.pop(0)
+        else:
+            entry = _EMPTY_CARTOGRAPHER if is_cartographer else _EMPTY_DISTILLER
+
+        payload = entry(prompt) if callable(entry) else entry
+        text = json.dumps(payload)
+
+        self.calls += 1
+        # Rough usage accounting so CachePolicy.usage is non-zero and realistic.
+        self._last = Usage(input_tokens=len(prompt) // 4, output_tokens=len(text) // 4)
+        self.transcript.append((role, payload))
+        return text
+
+    def last_usage(self) -> Usage:
+        return self._last


### PR DESCRIPTION
Explores github.com/zhuohangu/peek by running its real CachePolicy control
flow end to end. Since the sandbox has no LLM API key, a ScriptedLMClient
stub replays canned Distiller/Cartographer JSON while every other moving
part (ContextMap edits, scoring, the priority Evictor, evolve freeze,
save/load) is genuine PEEK code.

- experiment_1_mechanics.py: deterministic layer, no LLM
- experiment_2_policy_loop.py: full update loop over a 5-question workload,
  showing bootstrap, self-correction, budget eviction, and freezing

https://claude.ai/code/session_017LMj6X2KzNLBfmqkQGfhya