### PR TITLE
ebpf-core-firecracker-depot: CO-RE eBPF matrix under FC on Depot CI (hand-rolled + LVH)

### DIFF
--- a/ebpf-core-firecracker-depot/.depot/workflows/boot-single-kernel.yml
+++ b/ebpf-core-firecracker-depot/.depot/workflows/boot-single-kernel.yml
@@ -1,0 +1,45 @@
+name: Boot Linux guest + load CO-RE eBPF probe (single kernel)
+
+# Pulls the cached ebpf-runner image — firecracker, util-linux, one
+# Ubuntu 6.8 kernel ELF, an initrd containing the static-musl loader
+# + probe.bpf.o, and the boot script all baked in. Boots the guest,
+# loader runs as PID 1, loads + attaches the probe, fires execve,
+# captures the ringbuf event, prints JSON to ttyS0, reboots.
+#
+# Stage 1 acceptance: BPF_RESULT_END marker, verdict OK, events >= 1.
+
+on:
+  workflow_dispatch: {}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  boot:
+    runs-on: depot-ubuntu-24.04
+    timeout-minutes: 5
+    container:
+      image: registry.depot.dev/lmpn2xx8kz:ebpf-runner-latest
+      credentials:
+        username: x-token
+        password: ${{ secrets.AEGIS_DEPOT_TOKEN }}
+      options: >-
+        --device=/dev/kvm
+        --cap-add=SYS_ADMIN
+        --security-opt seccomp=unconfined
+        --security-opt apparmor=unconfined
+    steps:
+      - name: Verify image + KVM passthrough
+        run: |
+          set -eux
+          ls -l /dev/kvm
+          firecracker --version
+          file /opt/guest/vmlinux
+          ls -lh /opt/guest/vmlinux /opt/guest/initrd.cpio /opt/run_linux_guest.sh
+
+      - name: Boot Linux guest and load probe
+        run: |
+          bash /opt/run_linux_guest.sh \
+            /opt/guest/vmlinux \
+            /opt/guest/initrd.cpio

--- a/ebpf-core-firecracker-depot/.depot/workflows/build-runner-image.yml
+++ b/ebpf-core-firecracker-depot/.depot/workflows/build-runner-image.yml
@@ -1,0 +1,36 @@
+name: Build CO-RE eBPF runner image
+
+# Cross-compiles probe.bpf.o + static-musl loader, fetches an Ubuntu
+# 6.8 kernel + decompresses it to vmlinux ELF, generates vmlinux.h
+# from its BTF, builds an initrd cpio, and bakes everything plus
+# firecracker into a runner image saved to the Depot Registry as
+# `registry.depot.dev/lmpn2xx8kz:ebpf-runner-latest`.
+#
+# First build: ~3-5 min (Ubuntu kernel deb ~80 MB, libbpf compile).
+# Repeat builds reuse Depot's BuildKit layer cache (~30 s).
+
+on:
+  workflow_dispatch: {}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    runs-on: depot-ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build runner image and save to Depot Registry
+        uses: depot/build-push-action@v1
+        with:
+          project: lmpn2xx8kz
+          token: ${{ secrets.AEGIS_DEPOT_TOKEN }}
+          context: ebpf-core-firecracker-depot
+          file: ebpf-core-firecracker-depot/infra/docker/ebpf-runner.Dockerfile
+          platforms: linux/amd64
+          save: true
+          save-tag: ebpf-runner-latest
+          push: false

--- a/ebpf-core-firecracker-depot/.depot/workflows/build-runner-lvh-image.yml
+++ b/ebpf-core-firecracker-depot/.depot/workflows/build-runner-lvh-image.yml
@@ -1,0 +1,37 @@
+name: Build CO-RE eBPF runner image (LVH kernel source)
+
+# Same probe.bpf.o + same static-musl loader + same initrd, but
+# kernel ELFs come from Cilium's little-vm-helper kernel catalog at
+# quay.io/lvh-images/complexity-test:<version>-<timestamp> instead
+# of being hand-fetched from Ubuntu's apt archive.
+#
+# Saved as `registry.depot.dev/lmpn2xx8kz:ebpf-lvh-runner-latest`.
+#
+# Pulling 4 LVH images is ~1 GB of network on the first build; ~30 s
+# cached after.
+
+on:
+  workflow_dispatch: {}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    runs-on: depot-ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build LVH-backed runner image and save to Depot Registry
+        uses: depot/build-push-action@v1
+        with:
+          project: lmpn2xx8kz
+          token: ${{ secrets.AEGIS_DEPOT_TOKEN }}
+          context: ebpf-core-firecracker-depot
+          file: ebpf-core-firecracker-depot/infra/docker/ebpf-runner-lvh.Dockerfile
+          platforms: linux/amd64
+          save: true
+          save-tag: ebpf-lvh-runner-latest
+          push: false

--- a/ebpf-core-firecracker-depot/.depot/workflows/matrix-kernels-lvh.yml
+++ b/ebpf-core-firecracker-depot/.depot/workflows/matrix-kernels-lvh.yml
@@ -1,0 +1,98 @@
+name: Matrix CO-RE eBPF probe across LVH kernels (5.15 / 6.1 / 6.6 / 6.12)
+
+# Same loop as matrix-kernels.yml but driven against the LVH-backed
+# runner image (4 kernels, including 6.6 and 6.12 that we couldn't
+# easily get from Ubuntu apt).
+#
+# Both matrices run the same probe.bpf.o; the only difference is the
+# kernel source.
+
+on:
+  workflow_dispatch: {}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  matrix:
+    runs-on: depot-ubuntu-24.04
+    timeout-minutes: 10
+    container:
+      image: registry.depot.dev/lmpn2xx8kz:ebpf-lvh-runner-latest
+      credentials:
+        username: x-token
+        password: ${{ secrets.AEGIS_DEPOT_TOKEN }}
+      options: >-
+        --device=/dev/kvm
+        --cap-add=SYS_ADMIN
+        --security-opt seccomp=unconfined
+        --security-opt apparmor=unconfined
+    steps:
+      - name: Verify image + KVM passthrough
+        run: |
+          set -eux
+          ls -l /dev/kvm
+          firecracker --version
+          ls -lh /opt/guest/
+
+      - name: Boot LVH guests in sequence, load probe in each
+        run: |
+          set -uo pipefail
+
+          declare -A verdict events boot_ms note
+          mkdir -p /tmp/matrix
+
+          for k in /opt/guest/vmlinux-*; do
+            v="${k#/opt/guest/vmlinux-}"
+            [[ "$v" == "*" ]] && continue
+            log="/tmp/matrix/$v.log"
+
+            echo
+            echo "==============================================="
+            echo "== kernel $v (LVH)"
+            echo "==============================================="
+
+            bash /opt/run_linux_guest.sh "$k" /opt/guest/initrd.cpio 2>&1 | tee "$log" || true
+
+            json="$(awk '/BPF_RESULT_BEGIN/{p=1; next} /BPF_RESULT_END/{p=0} p' "$log" | tr -d '\r' | tr -d '\n')"
+
+            if [[ -z "$json" ]]; then
+              verdict["$v"]="NO_RESULT"
+              events["$v"]=0
+              boot_ms["$v"]=0
+              note["$v"]="(no markers in serial)"
+            else
+              verdict["$v"]="$(echo "$json" | jq -r '.verdict // "?"')"
+              events["$v"]="$(echo "$json" | jq -r '.events // 0')"
+              boot_ms["$v"]="$(echo "$json" | jq -r '.boot_to_load_ms // 0')"
+              if [[ "${verdict[$v]}" != "OK" ]]; then
+                stage="$(echo "$json" | jq -r '.stage // ""')"
+                note["$v"]="(stage=$stage)"
+              else
+                note["$v"]=""
+              fi
+            fi
+          done
+
+          echo
+          echo "==============================================="
+          echo "== LVH matrix summary"
+          echo "==============================================="
+          printf '  %-10s %-12s %-15s %-8s %s\n' KERNEL STATUS BOOT_TO_LOAD EVENTS NOTE
+          printf '  %-10s %-12s %-15s %-8s %s\n' ------ ------ ------------ ------ ----
+          fail=0
+          for k in /opt/guest/vmlinux-*; do
+            v="${k#/opt/guest/vmlinux-}"
+            [[ "$v" == "*" ]] && continue
+            printf '  %-10s %-12s %-15s %-8s %s\n' \
+              "$v" "${verdict[$v]:-?}" "${boot_ms[$v]:-?}ms" \
+              "${events[$v]:-?}" "${note[$v]:-}"
+            [[ "${verdict[$v]:-}" == "OK" ]] || fail=1
+          done
+
+          if (( fail )); then
+            echo "OVERALL: at least one LVH kernel did NOT resolve CO-RE relocations"
+            exit 1
+          fi
+          echo "OVERALL: all LVH kernels accepted the probe"

--- a/ebpf-core-firecracker-depot/.depot/workflows/matrix-kernels.yml
+++ b/ebpf-core-firecracker-depot/.depot/workflows/matrix-kernels.yml
@@ -1,0 +1,109 @@
+name: Matrix-boot CO-RE eBPF probe across N kernel versions
+
+# Uses the same cached ebpf-runner image as boot-single-kernel.yml,
+# but loops `run_linux_guest.sh` across every Linux kernel baked into
+# /opt/guest/vmlinux-* — same compiled .bpf.o, same initrd, different
+# kernel ABI. Each kernel that resolves CO-RE relocations and emits
+# at least one event passes.
+#
+# Job fails if ANY kernel returns a non-OK verdict — that's the
+# point: a failure is a CI signal that the probe's field-access
+# encodings don't match the target kernel's BTF.
+
+on:
+  workflow_dispatch: {}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  matrix:
+    runs-on: depot-ubuntu-24.04
+    timeout-minutes: 10
+    container:
+      image: registry.depot.dev/lmpn2xx8kz:ebpf-runner-latest
+      credentials:
+        username: x-token
+        password: ${{ secrets.AEGIS_DEPOT_TOKEN }}
+      options: >-
+        --device=/dev/kvm
+        --cap-add=SYS_ADMIN
+        --security-opt seccomp=unconfined
+        --security-opt apparmor=unconfined
+    steps:
+      - name: Verify image + KVM passthrough
+        run: |
+          set -eux
+          ls -l /dev/kvm
+          firecracker --version
+          ls -lh /opt/guest/
+
+      - name: Boot Linux guests in sequence, load probe in each
+        run: |
+          set -uo pipefail
+
+          declare -A verdict
+          declare -A events
+          declare -A boot_ms
+          declare -A note
+
+          mkdir -p /tmp/matrix
+
+          # Probe each kernel ELF baked into /opt/guest/.
+          for k in /opt/guest/vmlinux-*; do
+            v="${k#/opt/guest/vmlinux-}"
+            [[ "$v" == "*" ]] && continue
+            log="/tmp/matrix/$v.log"
+
+            echo
+            echo "==============================================="
+            echo "== kernel $v"
+            echo "==============================================="
+
+            # Run, don't let a single guest failure stop the matrix.
+            bash /opt/run_linux_guest.sh "$k" /opt/guest/initrd.cpio 2>&1 | tee "$log" || true
+
+            # Extract the JSON between BPF_RESULT_BEGIN/END.
+            json="$(awk '/BPF_RESULT_BEGIN/{p=1; next} /BPF_RESULT_END/{p=0} p' "$log" | tr -d '\r' | tr -d '\n')"
+
+            if [[ -z "$json" ]]; then
+              verdict["$v"]="NO_RESULT"
+              events["$v"]=0
+              boot_ms["$v"]=0
+              note["$v"]="(no markers in serial)"
+            else
+              verdict["$v"]="$(echo "$json" | jq -r '.verdict // "?"')"
+              events["$v"]="$(echo "$json" | jq -r '.events // 0')"
+              boot_ms["$v"]="$(echo "$json" | jq -r '.boot_to_load_ms // 0')"
+              if [[ "${verdict[$v]}" != "OK" ]]; then
+                stage="$(echo "$json" | jq -r '.stage // ""')"
+                note["$v"]="(stage=$stage)"
+              else
+                note["$v"]=""
+              fi
+            fi
+          done
+
+          # Per-kernel summary
+          echo
+          echo "==============================================="
+          echo "== Matrix summary"
+          echo "==============================================="
+          printf '  %-10s %-12s %-15s %-8s %s\n' KERNEL STATUS BOOT_TO_LOAD EVENTS NOTE
+          printf '  %-10s %-12s %-15s %-8s %s\n' ------ ------ ------------ ------ ----
+          fail=0
+          for k in /opt/guest/vmlinux-*; do
+            v="${k#/opt/guest/vmlinux-}"
+            [[ "$v" == "*" ]] && continue
+            printf '  %-10s %-12s %-15s %-8s %s\n' \
+              "$v" "${verdict[$v]:-?}" "${boot_ms[$v]:-?}ms" \
+              "${events[$v]:-?}" "${note[$v]:-}"
+            [[ "${verdict[$v]:-}" == "OK" ]] || fail=1
+          done
+
+          if (( fail )); then
+            echo "OVERALL: at least one kernel did NOT resolve CO-RE relocations"
+            exit 1
+          fi
+          echo "OVERALL: all kernels accepted the probe"

--- a/ebpf-core-firecracker-depot/.dockerignore
+++ b/ebpf-core-firecracker-depot/.dockerignore
@@ -1,0 +1,4 @@
+*
+!src/
+!scripts/
+!infra/

--- a/ebpf-core-firecracker-depot/README.md
+++ b/ebpf-core-firecracker-depot/README.md
@@ -1,21 +1,34 @@
 # ebpf-core-firecracker-depot
 
-Load a CO-RE (Compile Once, Run Everywhere) eBPF probe inside a real
-Linux microVM under Firecracker on a [Depot](https://depot.dev)
-nested-virt CI runner. The point: validate that the probe's
-`BPF_CORE_READ` relocations resolve against the guest kernel's BTF —
-the kind of test that used to require bare-metal CI.
+Load a CO-RE (Compile Once, Run Everywhere) eBPF probe inside real
+Linux microVMs under Firecracker on a [Depot](https://depot.dev)
+nested-virt CI runner, then matrix-test the same compiled `.bpf.o`
+against several guest kernel ABIs.
 
-| What | Status |
-|---|---|
-| Stage 1 — single kernel, single probe, end-to-end CO-RE load + event capture | **green — 14 ms to libbpf-load, sub-ms to first event, ~15 s CI wall (cached)** |
-| Stage 2 — kernel matrix (5.15 / 6.1 / 6.8), hand-rolled kernel-fetch | **green — 3/3 OK, ~45 s CI wall** |
-| Stage 2 (alt) — kernel matrix via Cilium's `lvh kernels pull` (5.15 / 6.1 / 6.6 / 6.12) | **green — 4/4 OK, ~45 s CI wall** |
+The technical pattern (FC microVMs + matrix BPF testing) **is not
+new** — Cilium's [little-vm-helper](https://github.com/cilium/little-vm-helper)
+(LVH) does exactly this and is what real projects reach for. What's
+incrementally new is doing it inside a *managed* CI service without
+self-hosting bare metal or `*.metal`-class instances. This experiment
+ships both:
 
-Built on top of the FC plumbing patterns from the sibling
-[`unikraft-firecracker-depot`](../unikraft-firecracker-depot) experiment
-(PR #18) — the PTY-for-FC-stdout trick, the `x-token` Depot Registry
-auth, the multi-stage Dockerfile-then-runner-image pattern, all of it.
+- a **hand-rolled** FC + initrd + apt-fetch-kernel pipeline
+  (educational; shows the mechanics LVH hides), and
+- the same pipeline with **`lvh kernels pull`** swapped in for the
+  kernel-fetch step (recommended for real work; ~10 lines of
+  Dockerfile instead of ~50).
+
+| Stage | Path | Result |
+|---|---|---|
+| 1 — single kernel, single probe, end-to-end CO-RE load + event capture | hand-rolled, kernel 6.8 | **green** — 14 ms to libbpf-load, sub-ms to first event, ~15 s CI wall (cached) |
+| 2 — kernel matrix 5.15 / 6.1 / 6.8 | hand-rolled | **green** — 3/3 OK, ~45 s CI wall |
+| 2 — kernel matrix 5.15 / 6.1 / 6.6 / 6.12 | LVH | **green** — 4/4 OK, ~45 s CI wall |
+
+FC plumbing patterns (PTY-for-stdout, `x-token` Depot Registry auth,
+multi-stage Dockerfile → cached runner image) are inherited from the
+sibling [`unikraft-firecracker-depot`](../unikraft-firecracker-depot)
+experiment (PR #18) — see its README for the firsthand-discovered
+quirks.
 
 ## Quickstart
 
@@ -168,37 +181,66 @@ export DEPOT_TOKEN='depot_org_...'
 depot ci secrets list   # confirm AEGIS_DEPOT_TOKEN is set
 ```
 
-## What this proves about Depot's nested-virt runners
+## What's actually demonstrated here
 
-- The guest kernel is a real, full-fat Ubuntu 6.8 — not the runner's
-  kernel — booted under KVM acceleration. We control the version,
-  the config, the BTF.
-- libbpf's CO-RE relocator ran against the guest BTF at load time
-  and resolved every field access in the probe. If you swap in a
-  different kernel version (Stage 2), failures here would mean
-  "your probe's field accesses don't translate" — the same signal
-  you'd get from running on the real production kernel of a
-  different host.
-- Total wall time per kernel boot+probe-load+halt: ~1 second
-  in-guest, ~15 seconds CI overhead. Cheap enough to matrix-test
-  across many kernel versions in a single CI workflow.
+- **Same `probe.bpf.o` runs on four different guest kernel ABIs**
+  spanning ~3 years of Linux evolution (5.15 → 6.12). Each guest's
+  libbpf resolved every `BPF_CORE_READ` field access against its
+  own kernel's BTF at load time. That's CO-RE working empirically,
+  not in theory.
+- **LVH integration in a managed CI runner.** `lvh kernels pull`
+  in a build stage, kernel ELFs baked into the runner image, FC +
+  initrd + boot script the same as PR #18. No bare metal involved.
+- **The hand-rolled mechanics are visible** so you can see what
+  LVH hides: Ubuntu kernel deb extraction, `extract-vmlinux` on
+  the vmlinuz, `bpftool btf dump file` for vmlinux.h, cpio newc
+  for the initrd, FC REST + PTY for serial capture.
+- **Per-kernel wall time: ~1 s in-guest, ~12 s CI overhead.** Most
+  of the wall is container pull + KVM init, not the boot itself.
+  Cheap enough that a per-PR multi-kernel CO-RE check is realistic.
 
-## Known gotchas (carried over from PR #18 + discovered here)
+### What is NOT new here
 
-1. **Depot Registry username is `x-token`**, not `depot`.
-2. **Static linking libbpf on Alpine** needs the dev packages PLUS
-   `zlib-static zstd-static xz-static bzip2-static`. The `libbpf-dev`
-   and `elfutils-dev` packages bundle the `.a` archives themselves;
-   there are no separate `-static` packages for those two. libelf
-   transitively calls into all four compression libraries for
-   compressed-ELF-section support.
-3. **`apt-get` doesn't know the latest kernel deb filename in advance** —
-   don't hardcode a launchpad URL. Use `apt-get install linux-image-virtual`
-   and read whatever `/boot/vmlinuz-*-generic` ended up there.
-4. Same FC-on-CI quirks as the sibling experiment: PTY for guest serial
-   (firecracker-microvm/firecracker#2729), Depot CI secrets can't start
-   with `DEPOT_`, container needs KVM passthrough + SYS_ADMIN +
-   seccomp/apparmor unconfined.
+- **Matrix BPF testing under microVMs** — Cilium has been doing
+  this in production with LVH for years.
+- **Loading eBPF in CI** — privileged Linux runners with BTF have
+  been able to do that on the host kernel for years (GitHub
+  Actions, GitLab, etc.).
+- **The CO-RE relocation pattern itself** — libbpf shipped this
+  with v1.0 in 2022.
+
+What is new: doing it on a **shared/managed CI service** without
+owning bare-metal infrastructure. That's a CI delivery-model
+change, not a kernel/BPF capability one.
+
+## Known gotchas (verified in this experiment)
+
+1. **LVH ships two OCI image families with confusingly similar names.**
+   - `quay.io/lvh-images/complexity-test:<ver>-<timestamp>` is a
+     whole-VM **qcow2 disk image** for use with `lvh run`. The
+     filesystem of the OCI image contains
+     `/data/images/complexity-test_<ver>.qcow2.zst` — no
+     `/boot/vmlinux` directly accessible.
+   - `quay.io/lvh-images/kernel-images:<ver>-main` is what
+     `lvh kernels pull` defaults to. The OCI image extracts as
+     `./<tag>/boot/vmlinux-X.Y.Z` (raw ELF, ready for FC).
+   - Reach for `kernel-images` if you want kernels; reach for
+     `complexity-test` only if you want LVH to run the whole VM.
+2. **`lvh` requires Go ≥ 1.25.7** to `go install`. Use
+   `golang:1.25-alpine` or later as the build stage base.
+3. **Depot Registry username is `x-token`**, not `depot`.
+4. **Static linking libbpf on Alpine** needs the dev packages PLUS
+   `zlib-static zstd-static xz-static bzip2-static`. `libbpf-dev`
+   and `elfutils-dev` bundle their `.a` archives themselves (no
+   separate `-static` apk). libelf transitively calls into all four
+   compression libraries for compressed-ELF-section support.
+5. **Don't hardcode launchpad URLs for kernel debs** — they 404 as
+   versions roll over. `apt-get install linux-image-virtual` and
+   read whatever `/boot/vmlinuz-*-generic` lands.
+6. Same FC-on-CI quirks as the sibling experiment: PTY for guest
+   serial (firecracker-microvm/firecracker#2729), Depot CI secrets
+   can't start with `DEPOT_`, container needs KVM passthrough +
+   SYS_ADMIN + seccomp/apparmor unconfined.
 
 ## Reference
 

--- a/ebpf-core-firecracker-depot/README.md
+++ b/ebpf-core-firecracker-depot/README.md
@@ -9,7 +9,7 @@ the kind of test that used to require bare-metal CI.
 | What | Status |
 |---|---|
 | Stage 1 — single kernel, single probe, end-to-end CO-RE load + event capture | **green — 14 ms to libbpf-load, sub-ms to first event, ~15 s CI wall (cached)** |
-| Stage 2 — kernel matrix (same probe against multiple kernel versions) | not started |
+| Stage 2 — kernel matrix (5.15 / 6.1 / 6.8) | **green — 3/3 kernels accepted the probe, ~45 s CI wall total** |
 
 Built on top of the FC plumbing patterns from the sibling
 [`unikraft-firecracker-depot`](../unikraft-firecracker-depot) experiment
@@ -30,7 +30,8 @@ cd ebpf-core-firecracker-depot
 # is already provisioned on the org.
 
 ./experiment.sh build      # ~90 s first time, ~30 s cached
-./experiment.sh boot       # ~15 s — boots Linux guest, loads probe, prints JSON
+./experiment.sh boot       # ~15 s — boots Linux 6.8 guest, loads probe, prints JSON
+./experiment.sh matrix     # ~45 s — boots 5.15 + 6.1 + 6.8, per-kernel summary table
 ```
 
 `./experiment.sh --help` for the full command list.
@@ -65,13 +66,38 @@ Translation:
   `bpf_object__load()` returning success. Essentially the
   KVM-accelerated kernel boot plus libbpf's relocation pass.
 
+## Stage 2 result snapshot
+
+```
+== Matrix summary
+  KERNEL     STATUS       BOOT_TO_LOAD    EVENTS   NOTE
+  ------     ------       ------------    ------   ----
+  5.15       OK           43ms            1
+  6.1        OK           12ms            1
+  6.8        OK           13ms            1
+OVERALL: all kernels accepted the probe
+```
+
+Same `probe.bpf.o` (compiled against 6.8's BTF), same initrd, same
+loader — booted against three different kernel ABIs spanning ~3
+years of Linux kernel evolution. libbpf relocated each
+`BPF_CORE_READ` field access against the running kernel's BTF.
+5.15 is slightly slower to load (older BPF JIT path); 6.1 and 6.8
+are both ~12 ms.
+
+A kernel that *fails* CO-RE here would show up with
+`STATUS=FAIL note=(stage=load)` and the workflow exits non-zero —
+which is the useful CI signal for "this probe needs updating to
+match a struct layout change upstream."
+
 ## Layout
 
 ```
 ebpf-core-firecracker-depot/
 ├── .depot/workflows/
 │   ├── build-runner-image.yml       # build + cache ebpf-runner image
-│   └── boot-single-kernel.yml       # boot Linux guest + load probe
+│   ├── boot-single-kernel.yml       # boot Linux 6.8 guest + load probe
+│   └── matrix-kernels.yml           # boot 5.15 + 6.1 + 6.8 in sequence
 ├── src/
 │   ├── probe.bpf.c                  # CO-RE eBPF probe
 │   ├── loader.c                     # static-musl PID 1 / libbpf loader
@@ -81,8 +107,7 @@ ebpf-core-firecracker-depot/
 │                                    # build probe+loader, build initrd, runtime
 ├── scripts/
 │   └── run_linux_guest.sh           # FC REST + PTY for serial, JSON marker parse
-├── kernels/                         # (stage 2: per-kernel manifest goes here)
-├── experiment.sh                    # ./experiment.sh boot
+├── experiment.sh                    # ./experiment.sh boot | matrix
 ├── .dockerignore
 ├── depot.json                       # { "id": "lmpn2xx8kz" }
 ├── SPEC.md                          # the original spec for this experiment

--- a/ebpf-core-firecracker-depot/README.md
+++ b/ebpf-core-firecracker-depot/README.md
@@ -1,25 +1,147 @@
-# ebpf-core-firecracker-depot — placeholder
+# ebpf-core-firecracker-depot
 
-> **This directory is a scaffold for a future experiment that hasn't
-> been built yet.** The full spec lives in [`SPEC.md`](SPEC.md). Read
-> that first; it links back to a sibling experiment in this same
-> repo (`unikraft-firecracker-depot/`, PR #18) which already shipped
-> the Firecracker plumbing patterns you'll reuse here.
+Load a CO-RE (Compile Once, Run Everywhere) eBPF probe inside a real
+Linux microVM under Firecracker on a [Depot](https://depot.dev)
+nested-virt CI runner. The point: validate that the probe's
+`BPF_CORE_READ` relocations resolve against the guest kernel's BTF —
+the kind of test that used to require bare-metal CI.
 
-## What this is
+| What | Status |
+|---|---|
+| Stage 1 — single kernel, single probe, end-to-end CO-RE load + event capture | **green — 14 ms to libbpf-load, sub-ms to first event, ~15 s CI wall (cached)** |
+| Stage 2 — kernel matrix (same probe against multiple kernel versions) | not started |
 
-A planned experiment to demonstrate CO-RE (Compile Once, Run Everywhere)
-eBPF probe loading **across multiple Linux kernel versions** inside
-Firecracker microVMs on Depot CI's nested-virt runners. The "kernel
-matrix in regular CI" capability is the genuinely new thing the
-nested-virt runners unlock; everything else has been possible on
-privileged CI containers for years.
+Built on top of the FC plumbing patterns from the sibling
+[`unikraft-firecracker-depot`](../unikraft-firecracker-depot) experiment
+(PR #18) — the PTY-for-FC-stdout trick, the `x-token` Depot Registry
+auth, the multi-stage Dockerfile-then-runner-image pattern, all of it.
 
-## How to start
+## Quickstart
 
-Open a new coding session in this repo, point it at this directory,
-and feed it `SPEC.md`. The spec is self-contained and references the
-sibling PR for any plumbing pattern that's already proven.
+```bash
+curl -L https://depot.dev/install-cli.sh | sh
+export PATH=$HOME/.depot/bin:$PATH
+export DEPOT_TOKEN='depot_org_...'
 
-Sibling experiment (FC plumbing already shipped, read this for patterns):
-<https://github.com/N3mes1s/Playground/pull/18>
+cd ebpf-core-firecracker-depot
+
+# One-time per Depot org. depot.json already points at project
+# lmpn2xx8kz (shared with the sibling experiment). AEGIS_DEPOT_TOKEN
+# is already provisioned on the org.
+
+./experiment.sh build      # ~90 s first time, ~30 s cached
+./experiment.sh boot       # ~15 s — boots Linux guest, loads probe, prints JSON
+```
+
+`./experiment.sh --help` for the full command list.
+
+## Stage 1 result snapshot
+
+```
+--- guest serial ---
+[    0.000000] Command line: console=ttyS0 reboot=k panic=1 root=/dev/ram0 rw pci=off
+[    0.023686] Kernel command line: console=ttyS0 reboot=k panic=1 ...
+[    0.609691] Loaded X.509 cert 'Canonical Ltd. Kernel Module Signing 2025 Kmod ...'
+BPF_RESULT_BEGIN
+{"verdict":"OK","events":1,"pid":75,"ppid":1,"comm":"init",
+ "core_relocs":"resolved","boot_to_load_ms":14,"load_to_event_ms":0}
+BPF_RESULT_END
+Firecracker exiting successfully. exit_code=0
+```
+
+Translation:
+
+- `core_relocs:"resolved"` — libbpf successfully resolved every
+  `BPF_CORE_READ` in `probe.bpf.c` against the kernel's BTF at load
+  time. CO-RE guarantee made empirical.
+- `events:1` — the probe fired on the loader's own `execve` (we
+  intentionally exec a path that doesn't exist; the tracepoint is
+  at syscall entry, before the lookup fails).
+- `pid:75, ppid:1, comm:"init"` — fields read from
+  `task_struct.{pid, real_parent.pid, comm}` via CO-RE. PID 1 is
+  the loader; PID 75 is the forked child whose `execve()` triggered
+  the probe.
+- `boot_to_load_ms:14` — wall time from PID 1 starting to
+  `bpf_object__load()` returning success. Essentially the
+  KVM-accelerated kernel boot plus libbpf's relocation pass.
+
+## Layout
+
+```
+ebpf-core-firecracker-depot/
+├── .depot/workflows/
+│   ├── build-runner-image.yml       # build + cache ebpf-runner image
+│   └── boot-single-kernel.yml       # boot Linux guest + load probe
+├── src/
+│   ├── probe.bpf.c                  # CO-RE eBPF probe
+│   ├── loader.c                     # static-musl PID 1 / libbpf loader
+│   └── Makefile                     # clang -target bpf, gcc -static
+├── infra/docker/
+│   └── ebpf-runner.Dockerfile       # 5-stage: fetch kernel, gen vmlinux.h,
+│                                    # build probe+loader, build initrd, runtime
+├── scripts/
+│   └── run_linux_guest.sh           # FC REST + PTY for serial, JSON marker parse
+├── kernels/                         # (stage 2: per-kernel manifest goes here)
+├── experiment.sh                    # ./experiment.sh boot
+├── .dockerignore
+├── depot.json                       # { "id": "lmpn2xx8kz" }
+├── SPEC.md                          # the original spec for this experiment
+└── README.md
+```
+
+## Setup (one-time, per Depot org)
+
+```bash
+export DEPOT_TOKEN='depot_org_...'
+
+# Reuses the sibling experiment's project (lmpn2xx8kz). Tags are
+# scoped per-tag, not per-project, so there's no clash with
+# helloworld-runner-latest / native-runner-latest.
+
+depot ci secrets list   # confirm AEGIS_DEPOT_TOKEN is set
+```
+
+## What this proves about Depot's nested-virt runners
+
+- The guest kernel is a real, full-fat Ubuntu 6.8 — not the runner's
+  kernel — booted under KVM acceleration. We control the version,
+  the config, the BTF.
+- libbpf's CO-RE relocator ran against the guest BTF at load time
+  and resolved every field access in the probe. If you swap in a
+  different kernel version (Stage 2), failures here would mean
+  "your probe's field accesses don't translate" — the same signal
+  you'd get from running on the real production kernel of a
+  different host.
+- Total wall time per kernel boot+probe-load+halt: ~1 second
+  in-guest, ~15 seconds CI overhead. Cheap enough to matrix-test
+  across many kernel versions in a single CI workflow.
+
+## Known gotchas (carried over from PR #18 + discovered here)
+
+1. **Depot Registry username is `x-token`**, not `depot`.
+2. **Static linking libbpf on Alpine** needs the dev packages PLUS
+   `zlib-static zstd-static xz-static bzip2-static`. The `libbpf-dev`
+   and `elfutils-dev` packages bundle the `.a` archives themselves;
+   there are no separate `-static` packages for those two. libelf
+   transitively calls into all four compression libraries for
+   compressed-ELF-section support.
+3. **`apt-get` doesn't know the latest kernel deb filename in advance** —
+   don't hardcode a launchpad URL. Use `apt-get install linux-image-virtual`
+   and read whatever `/boot/vmlinuz-*-generic` ended up there.
+4. Same FC-on-CI quirks as the sibling experiment: PTY for guest serial
+   (firecracker-microvm/firecracker#2729), Depot CI secrets can't start
+   with `DEPOT_`, container needs KVM passthrough + SYS_ADMIN +
+   seccomp/apparmor unconfined.
+
+## Reference
+
+- libbpf-bootstrap (canonical CO-RE skeleton):
+  <https://github.com/libbpf/libbpf-bootstrap>
+- libbpf:
+  <https://github.com/libbpf/libbpf>
+- Firecracker boot-source API:
+  <https://github.com/firecracker-microvm/firecracker/blob/main/docs/api_requests/actions.md>
+- CO-RE explainer (Andrii Nakryiko):
+  <https://nakryiko.com/posts/bpf-portability-and-co-re/>
+- Sibling experiment PR #18 (FC plumbing patterns reused here):
+  <https://github.com/N3mes1s/Playground/pull/18>

--- a/ebpf-core-firecracker-depot/README.md
+++ b/ebpf-core-firecracker-depot/README.md
@@ -9,7 +9,8 @@ the kind of test that used to require bare-metal CI.
 | What | Status |
 |---|---|
 | Stage 1 — single kernel, single probe, end-to-end CO-RE load + event capture | **green — 14 ms to libbpf-load, sub-ms to first event, ~15 s CI wall (cached)** |
-| Stage 2 — kernel matrix (5.15 / 6.1 / 6.8) | **green — 3/3 kernels accepted the probe, ~45 s CI wall total** |
+| Stage 2 — kernel matrix (5.15 / 6.1 / 6.8), hand-rolled kernel-fetch | **green — 3/3 OK, ~45 s CI wall** |
+| Stage 2 (alt) — kernel matrix via Cilium's `lvh kernels pull` (5.15 / 6.1 / 6.6 / 6.12) | **green — 4/4 OK, ~45 s CI wall** |
 
 Built on top of the FC plumbing patterns from the sibling
 [`unikraft-firecracker-depot`](../unikraft-firecracker-depot) experiment
@@ -29,9 +30,14 @@ cd ebpf-core-firecracker-depot
 # lmpn2xx8kz (shared with the sibling experiment). AEGIS_DEPOT_TOKEN
 # is already provisioned on the org.
 
-./experiment.sh build      # ~90 s first time, ~30 s cached
-./experiment.sh boot       # ~15 s — boots Linux 6.8 guest, loads probe, prints JSON
-./experiment.sh matrix     # ~45 s — boots 5.15 + 6.1 + 6.8, per-kernel summary table
+./experiment.sh build       # ~90 s first time, ~30 s cached
+./experiment.sh boot        # ~15 s — boots Linux 6.8 guest, loads probe, prints JSON
+./experiment.sh matrix      # ~45 s — boots 5.15 + 6.1 + 6.8 (hand-rolled kernels)
+
+# Same probe, but the kernel ELFs come from lvh kernels pull instead
+# of our Ubuntu-apt-and-extract-vmlinux dance:
+./experiment.sh build-lvh   # ~90 s first time, ~30 s cached
+./experiment.sh matrix-lvh  # ~45 s — 5.15 + 6.1 + 6.6 + 6.12 via lvh
 ```
 
 `./experiment.sh --help` for the full command list.
@@ -66,7 +72,7 @@ Translation:
   `bpf_object__load()` returning success. Essentially the
   KVM-accelerated kernel boot plus libbpf's relocation pass.
 
-## Stage 2 result snapshot
+## Stage 2 result snapshot — hand-rolled kernel fetch
 
 ```
 == Matrix summary
@@ -79,32 +85,68 @@ OVERALL: all kernels accepted the probe
 ```
 
 Same `probe.bpf.o` (compiled against 6.8's BTF), same initrd, same
-loader — booted against three different kernel ABIs spanning ~3
-years of Linux kernel evolution. libbpf relocated each
-`BPF_CORE_READ` field access against the running kernel's BTF.
-5.15 is slightly slower to load (older BPF JIT path); 6.1 and 6.8
-are both ~12 ms.
+loader — booted against three different kernel ABIs. libbpf
+relocated each `BPF_CORE_READ` field access against the running
+kernel's BTF.
 
 A kernel that *fails* CO-RE here would show up with
 `STATUS=FAIL note=(stage=load)` and the workflow exits non-zero —
 which is the useful CI signal for "this probe needs updating to
 match a struct layout change upstream."
 
+## Stage 2 result snapshot — LVH-backed kernel fetch
+
+```
+== LVH matrix summary
+  KERNEL     STATUS       BOOT_TO_LOAD    EVENTS   NOTE
+  ------     ------       ------------    ------   ----
+  5.15       OK           41ms            1
+  6.1        OK           13ms            1
+  6.6        OK           19ms            1
+  6.12       OK           16ms            1
+OVERALL: all LVH kernels accepted the probe
+```
+
+Same probe, same loader, same initrd, but the four kernel ELFs were
+pulled by `lvh kernels pull <ver>-main` from
+`quay.io/lvh-images/kernel-images`. The Dockerfile delta is small —
+~10 lines of `lvh kernels pull` instead of ~50 lines of apt + curl +
+extract-vmlinux — and we gain newer kernels (6.6, 6.12) that aren't
+in Noble's apt archive.
+
+### Hand-rolled vs LVH-backed: when to use which
+
+| | Hand-rolled (`build` + `matrix`) | LVH-backed (`build-lvh` + `matrix-lvh`) |
+|---|---|---|
+| Kernel source | Ubuntu apt + `kernel.ubuntu.com/mainline` debs | `lvh kernels pull` from `quay.io/lvh-images/kernel-images` |
+| Kernel versions available here | 5.15, 6.1, 6.8 | 5.15, 6.1, 6.6, 6.12 (and many more — `lvh kernels catalog`) |
+| Lines of Dockerfile for kernel fetch | ~50 | ~10 |
+| Trust surface | Canonical / kernel.ubuntu.com | quay.io/lvh-images (Cilium maintains) |
+| Why it's here | Learning value: shows what `extract-vmlinux` does, what BTF generation looks like | Production-shaped: this is how Cilium does kernel-matrix BPF CI |
+
+Both produce identical JSON verdicts on the same compiled
+`probe.bpf.o`. Pick LVH for real CO-RE matrix work; the hand-rolled
+variant is in this repo to make the underlying mechanics visible.
+
 ## Layout
 
 ```
 ebpf-core-firecracker-depot/
 ├── .depot/workflows/
-│   ├── build-runner-image.yml       # build + cache ebpf-runner image
+│   ├── build-runner-image.yml       # build + cache hand-rolled runner image
 │   ├── boot-single-kernel.yml       # boot Linux 6.8 guest + load probe
-│   └── matrix-kernels.yml           # boot 5.15 + 6.1 + 6.8 in sequence
+│   ├── matrix-kernels.yml           # 5.15 + 6.1 + 6.8 (hand-rolled)
+│   ├── build-runner-lvh-image.yml   # build + cache LVH-backed runner image
+│   └── matrix-kernels-lvh.yml       # 5.15 + 6.1 + 6.6 + 6.12 (lvh kernels pull)
 ├── src/
 │   ├── probe.bpf.c                  # CO-RE eBPF probe
 │   ├── loader.c                     # static-musl PID 1 / libbpf loader
 │   └── Makefile                     # clang -target bpf, gcc -static
 ├── infra/docker/
-│   └── ebpf-runner.Dockerfile       # 5-stage: fetch kernel, gen vmlinux.h,
-│                                    # build probe+loader, build initrd, runtime
+│   ├── ebpf-runner.Dockerfile       # 5-stage hand-rolled: fetch kernels via
+│   │                                # apt + dpkg-deb + extract-vmlinux
+│   └── ebpf-runner-lvh.Dockerfile   # same shape, but kernels come from
+│                                    # `lvh kernels pull`
 ├── scripts/
 │   └── run_linux_guest.sh           # FC REST + PTY for serial, JSON marker parse
 ├── experiment.sh                    # ./experiment.sh boot | matrix
@@ -164,6 +206,10 @@ depot ci secrets list   # confirm AEGIS_DEPOT_TOKEN is set
   <https://github.com/libbpf/libbpf-bootstrap>
 - libbpf:
   <https://github.com/libbpf/libbpf>
+- **Cilium's little-vm-helper (LVH)** — the production tool for
+  matrix-BPF-testing across kernels. The `lvh-backed` variant here
+  uses it directly:
+  <https://github.com/cilium/little-vm-helper>
 - Firecracker boot-source API:
   <https://github.com/firecracker-microvm/firecracker/blob/main/docs/api_requests/actions.md>
 - CO-RE explainer (Andrii Nakryiko):

--- a/ebpf-core-firecracker-depot/README.md
+++ b/ebpf-core-firecracker-depot/README.md
@@ -1,0 +1,25 @@
+# ebpf-core-firecracker-depot — placeholder
+
+> **This directory is a scaffold for a future experiment that hasn't
+> been built yet.** The full spec lives in [`SPEC.md`](SPEC.md). Read
+> that first; it links back to a sibling experiment in this same
+> repo (`unikraft-firecracker-depot/`, PR #18) which already shipped
+> the Firecracker plumbing patterns you'll reuse here.
+
+## What this is
+
+A planned experiment to demonstrate CO-RE (Compile Once, Run Everywhere)
+eBPF probe loading **across multiple Linux kernel versions** inside
+Firecracker microVMs on Depot CI's nested-virt runners. The "kernel
+matrix in regular CI" capability is the genuinely new thing the
+nested-virt runners unlock; everything else has been possible on
+privileged CI containers for years.
+
+## How to start
+
+Open a new coding session in this repo, point it at this directory,
+and feed it `SPEC.md`. The spec is self-contained and references the
+sibling PR for any plumbing pattern that's already proven.
+
+Sibling experiment (FC plumbing already shipped, read this for patterns):
+<https://github.com/N3mes1s/Playground/pull/18>

--- a/ebpf-core-firecracker-depot/SPEC.md
+++ b/ebpf-core-firecracker-depot/SPEC.md
@@ -1,0 +1,243 @@
+# Experiment — load + CO-RE-validate an eBPF probe inside Firecracker microVMs on Depot CI
+
+## Context
+
+Depot's nested-virtualization CI runners (`runs-on: depot-ubuntu-24.04`) expose `/dev/kvm` to a job container. That lets you spawn a real Linux microVM under Firecracker from a CI job and **control the guest kernel version** — exactly what you need to validate that a CO-RE (Compile Once, Run Everywhere) eBPF probe relocates correctly across kernel ABIs. Before this offering, that workflow needed bare-metal CI (self-hosted or Equinix-style metal); shared CI providers couldn't do it.
+
+We just shipped a sibling experiment in this same repo that nails the FC plumbing for Unikraft guests:
+
+Branch: `claude/unikraft-firecracker-depot-Lfwst` (open as PR #18)
+
+Specific files to read (use `mcp__github__get_file_contents` against `n3mes1s/playground` on that branch):
+
+- `unikraft-firecracker-depot/README.md` — Quickstart, layout, three FC gotchas
+- `unikraft-firecracker-depot/scripts/run_unikernel.sh` — the FC REST + PTY pattern
+- `unikraft-firecracker-depot/.depot/workflows/build-helloworld-image.yml` + `boot-helloworld-cached.yml` — the build-cache + boot pattern
+- `unikraft-firecracker-depot/infra/docker/helloworld-runner.Dockerfile` — multi-stage Dockerfile saved to Depot Registry
+- `unikraft-firecracker-depot/experiment.sh` — wrapper around `depot ci run`
+
+That experiment boots a Unikraft unikernel. **This one boots a real Linux kernel guest** (vmlinux + initrd) so eBPF actually has a Linux kernel to load against. Reuse the wrapper, the workflow shape, the Dockerfile pattern, and the serial-PTY trick.
+
+## Goal
+
+Demonstrate the full CI loop for CO-RE eBPF:
+
+1. Cross-compile a small CO-RE probe with libbpf + clang.
+2. Embed the `.bpf.o` and a static userspace loader into an initrd cpio.
+3. Boot **multiple Linux kernel versions** (e.g. 5.15, 6.1, 6.8 — pick 3) under Firecracker on a single Depot runner.
+4. For each kernel: load the probe via libbpf, attach to a tracepoint, generate ≥1 event, dump JSON to ttyS0.
+5. Host-side: parse the per-kernel JSON, succeed only if every kernel resolved CO-RE relocations and emitted ≥1 event.
+
+The end goal is a 3–5 minute CI workflow that proves a probe works against N kernel ABIs without anyone owning bare metal. The matrix-across-kernels capability is the genuinely new thing nested-virt unlocks; everything else has been possible on privileged CI containers for years.
+
+## Scope — two stages
+
+Don't start stage 2 until stage 1 is green.
+
+### Stage 1 — one kernel, one probe
+
+- Cross-compile a "BPF_OK" probe attached to `sys_enter_execve` (or any always-firing tracepoint).
+- Boot **one** Linux kernel under FC, load the probe inside the guest via a static-musl loader binary in the initrd, write `BPF_RESULT_BEGIN…END` JSON to ttyS0, reboot to halt cleanly.
+- Host-side assertion: the JSON marker, `verdict: OK`, `events ≥ 1`.
+
+### Stage 2 — kernel matrix
+
+- Loop the same `.bpf.o` and loader across 3+ kernel versions.
+- Surface a per-kernel pass/fail table like the sibling repo's `smoke-catalog-images.yml`.
+- A kernel that fails CO-RE relocation is the interesting failure mode — keep that case loud, don't silently skip.
+
+## Pattern to mirror (verbatim where it makes sense)
+
+1. **Workflows** at `ebpf-core-firecracker-depot/.depot/workflows/*.yml`. Add `defaults: { run: { shell: bash } }`. Use the same `container:` block with `--device=/dev/kvm --cap-add=SYS_ADMIN --security-opt seccomp=unconfined --security-opt apparmor=unconfined`.
+2. **Runner image** built via `depot/build-push-action@v1` with `save: true, save-tag: <name>-latest`. Multi-stage Dockerfile: stage A cross-compiles BPF + builds initrd + fetches/unpacks vmlinux(es); stage B is the runtime image with firecracker + util-linux + the baked-in artifacts.
+3. **Depot Registry pull** in the consumer workflow: `container.image: registry.depot.dev/<project_id>:<tag>` with `credentials: { username: x-token, password: ${{ secrets.AEGIS_DEPOT_TOKEN }} }`.
+4. **FC REST + PTY**: take `scripts/run_unikernel.sh` and adapt as `scripts/run_linux_guest.sh`:
+   - Replace boot_args with Linux-style `"console=ttyS0 reboot=k panic=1"`. (The Unikraft `"<app> -- <args>"` convention does NOT apply here.)
+   - Pass `initrd_path` in the `/boot-source` body.
+   - Pattern to match becomes your `BPF_RESULT_END` marker.
+   - Bump `mem_size_mib` to 256–512.
+
+## Required setup
+
+### Depot CI secret
+
+`AEGIS_DEPOT_TOKEN` is already provisioned on org `1crx4tb65r` (PR #18 uses it). Reuse it. Don't add a new secret unless you have a reason. The token rule from PR #18 still applies: CI secret names cannot start with `DEPOT_`.
+
+### Depot project
+
+PR #18 uses project `lmpn2xx8kz` (`unikraft-playground`). Two options:
+
+- **Reuse it**: registry tags are scoped by tag string, not project, so as long as you use distinct tags (`ebpf-runner-latest`, etc.) there's no clash. Easiest.
+- **New project**: `depot projects create ebpf-playground`. The token can create but cannot list/delete — see PR #18 gotcha #2.
+
+### Local
+
+```bash
+curl -L https://depot.dev/install-cli.sh | sh
+export PATH=$HOME/.depot/bin:$PATH
+export DEPOT_TOKEN='depot_org_...'   # from the human
+```
+
+## Concrete layout
+
+```
+ebpf-core-firecracker-depot/
+├── .depot/workflows/
+│   ├── build-runner-image.yml        # bake kernels + probe + loader + FC
+│   ├── boot-single-kernel.yml        # stage 1
+│   └── matrix-kernels.yml            # stage 2
+├── src/
+│   ├── probe.bpf.c                   # CO-RE probe
+│   ├── loader.c                      # libbpf userspace loader
+│   └── Makefile                      # cross-compile both, vendor libbpf
+├── kernels/
+│   └── manifest.yaml                 # (name, source-url, sha256) per kernel
+├── infra/docker/
+│   └── ebpf-runner.Dockerfile        # multi-stage build
+├── scripts/
+│   ├── run_linux_guest.sh            # adapted from sibling's run_unikernel.sh
+│   └── build_initrd.sh               # cpio newc with /init + /probe.bpf.o
+├── experiment.sh                     # wrapper, mirror sibling's structure
+├── depot.json
+└── README.md
+```
+
+## Probe — `src/probe.bpf.c`
+
+Make it exercise at least one CO-RE relocation so success is meaningful — not a hello-world that would pass on any kernel:
+
+```c
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_core_read.h>
+
+char LICENSE[] SEC("license") = "GPL";
+
+struct event { __u32 pid; char comm[16]; };
+
+struct {
+    __uint(type, BPF_MAP_TYPE_RINGBUF);
+    __uint(max_entries, 4096);
+} events SEC(".maps");
+
+SEC("tp/syscalls/sys_enter_execve")
+int handle_execve(void *ctx) {
+    struct task_struct *t = (void *)bpf_get_current_task();
+    struct event *e = bpf_ringbuf_reserve(&events, sizeof(*e), 0);
+    if (!e) return 0;
+    e->pid = BPF_CORE_READ(t, pid);
+    BPF_CORE_READ_STR_INTO(&e->comm, t, comm);
+    bpf_ringbuf_submit(e, 0);
+    return 0;
+}
+```
+
+`vmlinux.h` generation strategy: either pre-bake one (CO-RE handles the rest) OR generate per-kernel at runtime from `/sys/kernel/btf/vmlinux` inside the guest via `bpftool btf dump file ... format c`. Pre-baking is simpler.
+
+## Loader — `src/loader.c`
+
+Outline:
+
+- `bpf_object__open_file("/probe.bpf.o")`
+- `bpf_object__load(obj)` — this is where CO-RE relocations resolve. Capture errno + libbpf error string on failure.
+- Attach the program (`bpf_program__attach`).
+- Open the ringbuf, poll up to 5 s for ≥1 event. Run `execve("/bin/true", …)` from inside the loader so you generate your own event deterministically.
+- Print:
+
+  ```
+  BPF_RESULT_BEGIN
+  {"kernel":"6.1.0","verdict":"OK","events":3,"core_relocs":"resolved","boot_ms":712}
+  BPF_RESULT_END
+  ```
+
+  …or on failure:
+
+  ```
+  {"kernel":"5.4.0","verdict":"FAIL","stage":"load","libbpf_err":"…","core_relocs":"unresolved:struct task_struct field 'pid'"}
+  ```
+
+- `reboot(LINUX_REBOOT_CMD_RESTART)` so FC catches the halt and `exit_code=0`.
+
+Build with `musl-gcc -static`, link libbpf statically (vendor a known-good version, e.g. v1.4.x). Zero shared-lib deps in the initrd.
+
+## Kernel images
+
+Each guest needs:
+
+- `vmlinux` (ELF, with `CONFIG_DEBUG_INFO_BTF=y` so `/sys/kernel/btf/vmlinux` is exposed and CO-RE can resolve)
+- Minimal initrd cpio containing `/init` (the loader, exec'd as PID 1), `/probe.bpf.o`, and whatever the loader needs (probably nothing).
+
+Sources to try, easiest first:
+
+- **Firecracker test kernels**: <https://github.com/firecracker-microvm/firecracker/tree/main/tests/host_tools> — small, BTF on, designed for FC.
+- **Ubuntu LTS kernel debs**: unpack `linux-image-*-generic`, zstd-decompress the vmlinuz to extract vmlinux. The sibling aegis pipeline does this for Noble's 6.8 — install `zstd`, `lz4`, `lzop` in the Dockerfile (already noted in PR #18's earlier gotcha list).
+- **AmazonLinux Bottlerocket** kernels: tiny, BTF on, well-maintained.
+
+Pick 3 versions that span ≥ one major struct-layout change in `task_struct` so the CO-RE work is non-trivial — e.g. 5.10, 5.15, 6.1, 6.8 are all interesting choices.
+
+## Stage 1 acceptance
+
+- CI wall **< 90 s** (image cached, boot is fast).
+- Loader emits `BPF_RESULT_BEGIN/END` with `verdict:"OK"` and `events ≥ 1`.
+- FC `exit_code=0`.
+- `scripts/run_linux_guest.sh` exits 0.
+
+## Stage 2 acceptance
+
+- All N kernels report `verdict:"OK"`.
+- Per-kernel summary on stdout, e.g.:
+
+  ```
+  KERNEL          STATUS    BOOT_MS   EVENTS    CORE_RELOCS
+  linux-5.15.x    PASS      812       3         resolved
+  linux-6.1.x     PASS      745       3         resolved
+  linux-6.8.x     PASS      691       3         resolved
+  OVERALL: 3/3 kernels accepted the probe
+  ```
+
+- Job exits non-zero if any kernel fails — failure is itself a useful CI signal for "your CO-RE probe needs updating".
+
+## Gotchas (carried over from PR #18, verified)
+
+1. **Depot Registry username is `x-token`**, password is any depot token.
+2. **`depot projects list/delete` are scope-locked**; `create` works. Test projects are UI-only to clean up.
+3. **Guest serial is dropped** in non-interactive containers unless FC stdout is a PTY. Use `script -qfec "firecracker ..." serial.log` and route FC's own slog to `--log-path`. (firecracker-microvm/firecracker#2729)
+4. **`archive.ubuntu.com`** may be Cloudflare-blocked from Depot egress; the sibling defensively rewrites apt sources to `mirror.facebook.net`. We never confirmed the block ourselves but the swap is free.
+5. **CI secret names cannot start with `DEPOT_`** — `AEGIS_DEPOT_TOKEN` is what's already set up.
+6. **Workflows in the experiment subdir aren't auto-discovered**. Trigger via `experiment.sh` or `depot ci run --workflow ebpf-core-firecracker-depot/.depot/workflows/...`.
+
+## Things that differ from PR #18
+
+- **Boot args are Linux-style** (`console=ttyS0 reboot=k panic=1`). The Unikraft `<app> -- <args>` convention does not apply.
+- **initrd is required.** FC `/boot-source` needs `initrd_path` set.
+- **Kernel image is decompressed vmlinux ELF**, not Unikraft's stripped 32-bit multiboot ELF. Different artefact.
+- **Memory** ≥ 256 MiB. eBPF maps + libbpf load can use a few MiB.
+- **The PTY trick still applies** — copy it verbatim from `scripts/run_unikernel.sh`.
+
+## Deliverables
+
+One PR per stage:
+
+- workflow file(s)
+- src/ (probe + loader + Makefile)
+- Dockerfile + initrd builder
+- `experiment.sh` extended with `boot-single-kernel`, `matrix-kernels`, `build-runner-image`
+- README with per-stage result snapshot (matrix table for stage 2)
+- Reference to PR #18 for the FC plumbing patterns reused
+
+If you hit a blocker for > 30 min, write a PR comment with the repro + what you've ruled out. CO-RE relocation failures are themselves an interesting finding worth documenting in the README.
+
+## Resources
+
+- libbpf-bootstrap (canonical skeleton):
+  <https://github.com/libbpf/libbpf-bootstrap>
+- libbpf:
+  <https://github.com/libbpf/libbpf>
+- Firecracker boot-source API:
+  <https://github.com/firecracker-microvm/firecracker/blob/main/docs/api_requests/actions.md>
+- CO-RE explainer (Andrii Nakryiko):
+  <https://nakryiko.com/posts/bpf-portability-and-co-re/>
+- Sibling PR #18 (FC plumbing we already shipped):
+  <https://github.com/N3mes1s/Playground/pull/18>
+- Sibling branch (for direct file access):
+  <https://github.com/N3mes1s/Playground/tree/claude/unikraft-firecracker-depot-Lfwst>

--- a/ebpf-core-firecracker-depot/depot.json
+++ b/ebpf-core-firecracker-depot/depot.json
@@ -1,0 +1,1 @@
+{ "id": "lmpn2xx8kz" }

--- a/ebpf-core-firecracker-depot/experiment.sh
+++ b/ebpf-core-firecracker-depot/experiment.sh
@@ -18,14 +18,19 @@ usage() {
   cat <<EOF
 Usage: $(basename "$0") <command>
 
-  Commands:
-    build         Rebuild + cache the ebpf-runner image
+  Hand-rolled flavor (kernels fetched from Ubuntu apt):
+    build         Rebuild + cache the hand-rolled ebpf-runner image
                   (~3-5 min first time, ~30 s after).
-    boot          Boot a single Linux guest (6.8), load probe,
-                  capture verdict (~15 s wall after image cached).
-    matrix        Boot every kernel baked into the image (5.15,
-                  6.1, 6.8), load the same probe in each, print a
-                  per-kernel summary table.
+    boot          Boot one Linux 6.8 guest, load probe (~15 s wall).
+    matrix        Boot the 3 baked-in kernels (5.15, 6.1, 6.8) in
+                  sequence, print summary table.
+
+  LVH flavor (kernels pulled from quay.io/lvh-images/complexity-test):
+    build-lvh     Same as build, but uses LVH's pre-built kernel
+                  catalog. Ships 4 kernels (5.15, 6.1, 6.6, 6.12).
+    matrix-lvh    Run the LVH-backed matrix.
+
+  Common:
     list          Echo every available workflow path.
     status <id>   depot ci status passthrough.
     logs   <id>   depot ci logs passthrough.
@@ -52,9 +57,11 @@ run_wf() {
 
 cmd="${1:-}"
 case "$cmd" in
-  build)  run_wf build-runner-image.yml ;;
-  boot)   run_wf boot-single-kernel.yml ;;
-  matrix) run_wf matrix-kernels.yml ;;
+  build)      run_wf build-runner-image.yml ;;
+  boot)       run_wf boot-single-kernel.yml ;;
+  matrix)     run_wf matrix-kernels.yml ;;
+  build-lvh)  run_wf build-runner-lvh-image.yml ;;
+  matrix-lvh) run_wf matrix-kernels-lvh.yml ;;
   list)
     ls -1 "$REPO_ROOT/$WORKFLOWS_DIR_REL" | sed "s#^#$WORKFLOWS_DIR_REL/#"
     ;;

--- a/ebpf-core-firecracker-depot/experiment.sh
+++ b/ebpf-core-firecracker-depot/experiment.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Wrapper around `depot ci run` for the ebpf-core-firecracker-depot
+# experiment. Lets you do
+#   ./experiment.sh boot
+# instead of remembering the full workflow path.
+#
+# Required env: DEPOT_TOKEN (depot_org_...). See README for setup.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORKFLOWS_DIR_REL="ebpf-core-firecracker-depot/.depot/workflows"
+
+REPO="${REPO:-N3mes1s/Playground}"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") <command>
+
+  Commands:
+    build         Rebuild + cache the ebpf-runner image
+                  (~3-5 min first time, ~30 s after).
+    boot          Boot the Linux guest, load probe, capture verdict
+                  (~10 s wall after the image is cached).
+    list          Echo every available workflow path.
+    status <id>   depot ci status passthrough.
+    logs   <id>   depot ci logs passthrough.
+
+  Env overrides:
+    REPO          GitHub repo (default: N3mes1s/Playground)
+    DEPOT_TOKEN   required for any depot ci call
+EOF
+}
+
+require_token() {
+  if [[ -z "${DEPOT_TOKEN:-}" ]]; then
+    echo "ERROR: DEPOT_TOKEN is not set. See README 'Setup' section." >&2
+    exit 2
+  fi
+}
+
+run_wf() {
+  local file="$1"
+  require_token
+  cd "$REPO_ROOT"
+  exec depot ci run --repo "$REPO" --workflow "$WORKFLOWS_DIR_REL/$file"
+}
+
+cmd="${1:-}"
+case "$cmd" in
+  build)  run_wf build-runner-image.yml ;;
+  boot)   run_wf boot-single-kernel.yml ;;
+  list)
+    ls -1 "$REPO_ROOT/$WORKFLOWS_DIR_REL" | sed "s#^#$WORKFLOWS_DIR_REL/#"
+    ;;
+  status)
+    require_token; shift
+    exec depot ci status "$@"
+    ;;
+  logs)
+    require_token; shift
+    exec depot ci logs "$@"
+    ;;
+  -h|--help|help|"")
+    usage
+    ;;
+  *)
+    echo "unknown command: $cmd" >&2
+    echo >&2
+    usage
+    exit 2
+    ;;
+esac

--- a/ebpf-core-firecracker-depot/experiment.sh
+++ b/ebpf-core-firecracker-depot/experiment.sh
@@ -21,8 +21,11 @@ Usage: $(basename "$0") <command>
   Commands:
     build         Rebuild + cache the ebpf-runner image
                   (~3-5 min first time, ~30 s after).
-    boot          Boot the Linux guest, load probe, capture verdict
-                  (~10 s wall after the image is cached).
+    boot          Boot a single Linux guest (6.8), load probe,
+                  capture verdict (~15 s wall after image cached).
+    matrix        Boot every kernel baked into the image (5.15,
+                  6.1, 6.8), load the same probe in each, print a
+                  per-kernel summary table.
     list          Echo every available workflow path.
     status <id>   depot ci status passthrough.
     logs   <id>   depot ci logs passthrough.
@@ -51,6 +54,7 @@ cmd="${1:-}"
 case "$cmd" in
   build)  run_wf build-runner-image.yml ;;
   boot)   run_wf boot-single-kernel.yml ;;
+  matrix) run_wf matrix-kernels.yml ;;
   list)
     ls -1 "$REPO_ROOT/$WORKFLOWS_DIR_REL" | sed "s#^#$WORKFLOWS_DIR_REL/#"
     ;;

--- a/ebpf-core-firecracker-depot/infra/docker/ebpf-runner-lvh.Dockerfile
+++ b/ebpf-core-firecracker-depot/infra/docker/ebpf-runner-lvh.Dockerfile
@@ -1,0 +1,144 @@
+# syntax=docker/dockerfile:1.7
+#
+# LVH-backed runner image.
+#
+# Replaces the hand-rolled kernel-fetch in ebpf-runner.Dockerfile
+# (apt-install linux-image-virtual + curl+dpkg-deb pinned launchpad
+# debs + extract-vmlinux) with Cilium's little-vm-helper kernel
+# catalog at quay.io/lvh-images/complexity-test:<ver>-<timestamp>.
+#
+# Why bother:
+#   - LVH is the canonical "matrix BPF tests across kernel versions
+#     in CI" tooling — Cilium use it in their own production CI.
+#   - The images are pre-built with the BPF subsystems Cilium needs
+#     (BTF, all the verifier knobs, debug info). We don't have to
+#     trust an Ubuntu kernel's config or fish vmlinux out of vmlinuz.
+#   - Bumping to a new kernel == bump one tag string.
+#
+# Tags pinned to the timestamp Cilium's tests-datapath-verifier.yaml
+# uses on `main`. Renovate-bot rotates them upstream; bump here by
+# copy-pasting whatever cilium/cilium currently uses.
+
+# ----- LVH kernel "source" images ------------------------------------
+FROM quay.io/lvh-images/complexity-test:5.15-20260310.122539 AS lvh-5.15
+FROM quay.io/lvh-images/complexity-test:6.1-20260310.122539  AS lvh-6.1
+FROM quay.io/lvh-images/complexity-test:6.6-20260310.122539  AS lvh-6.6
+FROM quay.io/lvh-images/complexity-test:6.12-20260310.122539 AS lvh-6.12
+
+# ----- Stage A: extract one vmlinux per kernel -----------------------
+FROM ubuntu:24.04 AS kernel-collect
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN sed -i 's|http://archive.ubuntu.com/ubuntu|http://mirror.facebook.net/ubuntu|g; s|http://security.ubuntu.com/ubuntu|http://mirror.facebook.net/ubuntu|g' \
+        /etc/apt/sources.list /etc/apt/sources.list.d/*.sources 2>/dev/null || true \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends \
+        ca-certificates curl xz-utils zstd lz4 lzop binutils file \
+ && rm -rf /var/lib/apt/lists/*
+
+# LVH images put the bootable kernel at /boot/vmlinuz-X.Y.Z. Some
+# variants also expose a pre-extracted /boot/vmlinux-X.Y.Z. We copy
+# the whole /boot/ dir from each LVH stage and pick the right file
+# in the next RUN.
+COPY --from=lvh-5.15  /boot/ /tmp/k-5.15/
+COPY --from=lvh-6.1   /boot/ /tmp/k-6.1/
+COPY --from=lvh-6.6   /boot/ /tmp/k-6.6/
+COPY --from=lvh-6.12  /boot/ /tmp/k-6.12/
+
+# extract-vmlinux is the canonical kernel.org script that strips
+# the bootloader wrapper from a compressed bzImage. It groks gzip,
+# zstd, lz4, lzop, xz.
+RUN curl -fsSL https://raw.githubusercontent.com/torvalds/linux/v6.8/scripts/extract-vmlinux -o /usr/local/bin/extract-vmlinux \
+ && chmod +x /usr/local/bin/extract-vmlinux
+
+RUN mkdir -p /work && set -e && \
+    for v in 5.15 6.1 6.6 6.12; do \
+      echo "=== LVH kernel $v boot dir ==="; \
+      ls -la /tmp/k-$v/ || true; \
+      vmlinuz="$(ls /tmp/k-$v/vmlinuz-* 2>/dev/null | head -1)"; \
+      if [ -z "$vmlinuz" ]; then \
+        echo "ERROR: no vmlinuz found for $v" >&2; \
+        exit 1; \
+      fi; \
+      extract-vmlinux "$vmlinuz" > /work/vmlinux-$v; \
+      file /work/vmlinux-$v; \
+    done; \
+    ls -lh /work/vmlinux-*
+
+# ----- Stage B: generate vmlinux.h (from 6.12, newest of the matrix) -
+FROM alpine:3.20 AS btf-dump
+
+RUN apk add --no-cache bpftool file
+
+COPY --from=kernel-collect /work/vmlinux-6.12 /tmp/vmlinux
+
+RUN bpftool btf dump file /tmp/vmlinux format c > /tmp/vmlinux.h \
+ && wc -l /tmp/vmlinux.h \
+ && head -5 /tmp/vmlinux.h
+
+# ----- Stage C: build probe + static-musl loader ---------------------
+FROM alpine:3.20 AS build
+
+RUN apk add --no-cache \
+        build-base clang lld llvm \
+        libbpf-dev \
+        elfutils-dev \
+        zlib-dev zlib-static \
+        zstd-static xz-static bzip2-static \
+        linux-headers bpftool \
+        argp-standalone
+
+WORKDIR /src
+COPY src/ .
+COPY --from=btf-dump /tmp/vmlinux.h ./vmlinux.h
+
+RUN make -j$(nproc) all \
+ && file probe.bpf.o loader \
+ && ls -lh probe.bpf.o loader
+
+# ----- Stage D: initrd cpio ------------------------------------------
+FROM alpine:3.20 AS initrd-build
+
+RUN apk add --no-cache cpio
+
+COPY --from=build /src/loader      /initrd/init
+COPY --from=build /src/probe.bpf.o /initrd/probe.bpf.o
+
+RUN chmod +x /initrd/init \
+ && cd /initrd \
+ && find . -print0 | cpio -o -H newc --null > /tmp/initrd.cpio \
+ && ls -lh /tmp/initrd.cpio
+
+# ----- Stage E: final runtime image ----------------------------------
+FROM buildpack-deps:24.04-scm
+
+ENV DEBIAN_FRONTEND=noninteractive
+ARG FIRECRACKER_VERSION=v1.15.0
+
+RUN sed -i 's|http://archive.ubuntu.com/ubuntu|http://mirror.facebook.net/ubuntu|g; s|http://security.ubuntu.com/ubuntu|http://mirror.facebook.net/ubuntu|g' \
+        /etc/apt/sources.list /etc/apt/sources.list.d/*.sources 2>/dev/null || true \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends \
+        ca-certificates curl jq xz-utils tar gzip uuid-runtime file \
+        util-linux bsdmainutils \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL "https://github.com/firecracker-microvm/firecracker/releases/download/${FIRECRACKER_VERSION}/firecracker-${FIRECRACKER_VERSION}-x86_64.tgz" -o /tmp/fc.tgz \
+ && tar -xzf /tmp/fc.tgz -C /tmp \
+ && install -m 0755 "/tmp/release-${FIRECRACKER_VERSION}-x86_64/firecracker-${FIRECRACKER_VERSION}-x86_64" /usr/local/bin/firecracker \
+ && rm -rf /tmp/fc.tgz "/tmp/release-${FIRECRACKER_VERSION}-x86_64" \
+ && firecracker --version
+
+COPY --from=kernel-collect /work/vmlinux-5.15 /opt/guest/vmlinux-5.15
+COPY --from=kernel-collect /work/vmlinux-6.1  /opt/guest/vmlinux-6.1
+COPY --from=kernel-collect /work/vmlinux-6.6  /opt/guest/vmlinux-6.6
+COPY --from=kernel-collect /work/vmlinux-6.12 /opt/guest/vmlinux-6.12
+COPY --from=initrd-build   /tmp/initrd.cpio  /opt/guest/initrd.cpio
+COPY scripts/run_linux_guest.sh              /opt/run_linux_guest.sh
+
+RUN chmod +x /opt/run_linux_guest.sh \
+ && for v in 5.15 6.1 6.6 6.12; do file /opt/guest/vmlinux-$v; done \
+ && ls -lh /opt/guest/ /opt/run_linux_guest.sh
+
+WORKDIR /opt

--- a/ebpf-core-firecracker-depot/infra/docker/ebpf-runner-lvh.Dockerfile
+++ b/ebpf-core-firecracker-depot/infra/docker/ebpf-runner-lvh.Dockerfile
@@ -19,45 +19,34 @@
 # uses on `main`. Renovate-bot rotates them upstream; bump here by
 # copy-pasting whatever cilium/cilium currently uses.
 
-# ----- LVH kernel "source" images ------------------------------------
-FROM quay.io/lvh-images/complexity-test:5.15-20260310.122539 AS lvh-5.15
-FROM quay.io/lvh-images/complexity-test:6.1-20260310.122539  AS lvh-6.1
-FROM quay.io/lvh-images/complexity-test:6.6-20260310.122539  AS lvh-6.6
-FROM quay.io/lvh-images/complexity-test:6.12-20260310.122539 AS lvh-6.12
+# Use lvh CLI to pull kernels — it knows the registry URL convention
+# and handles whatever extraction is needed to surface vmlinuz/vmlinux
+# files. The complexity-test:<ver> images we tried directly are qcow2
+# VM disks, not raw kernel artefacts.
 
-# ----- Stage A: extract one vmlinux per kernel -----------------------
-FROM ubuntu:24.04 AS kernel-collect
+# ----- Stage A: install lvh CLI + pull kernels -----------------------
+FROM golang:1.23-alpine AS lvh-cli
+RUN apk add --no-cache git make build-base
+RUN go install github.com/cilium/little-vm-helper/cmd/lvh@latest
 
-ENV DEBIAN_FRONTEND=noninteractive
+FROM alpine:3.20 AS kernel-collect
 
-RUN sed -i 's|http://archive.ubuntu.com/ubuntu|http://mirror.facebook.net/ubuntu|g; s|http://security.ubuntu.com/ubuntu|http://mirror.facebook.net/ubuntu|g' \
-        /etc/apt/sources.list /etc/apt/sources.list.d/*.sources 2>/dev/null || true \
- && apt-get update \
- && apt-get install -y --no-install-recommends \
-        ca-certificates curl xz-utils zstd lz4 lzop binutils file \
- && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache ca-certificates curl file bash
 
-# Diagnostic: dump the full root of the smallest LVH image so we
-# can find where the bootable kernel actually lives in this image
-# family. (First pass assumed /boot/ which doesn't exist; this
-# unblocks figuring out the real path.)
-COPY --from=lvh-5.15  / /tmp/k-5.15/
+COPY --from=lvh-cli /go/bin/lvh /usr/local/bin/lvh
 
-# extract-vmlinux is the canonical kernel.org script that strips
-# the bootloader wrapper from a compressed bzImage. It groks gzip,
-# zstd, lz4, lzop, xz.
-RUN curl -fsSL https://raw.githubusercontent.com/torvalds/linux/v6.8/scripts/extract-vmlinux -o /usr/local/bin/extract-vmlinux \
- && chmod +x /usr/local/bin/extract-vmlinux
+# Probe what `lvh kernels pull` actually does with one version, then
+# dump the resulting tree so we know how to wire it for real.
+RUN lvh kernels --help 2>&1 | head -40 \
+ && echo '--- pull help ---' \
+ && lvh kernels pull --help 2>&1 | head -40
 
-RUN echo '=== top-level dirs of LVH 5.15 image ===' && \
-    ls -la /tmp/k-5.15/ && \
-    echo '=== any file with "vmlin" in name ===' && \
-    find /tmp/k-5.15 -maxdepth 6 -iname '*vmlin*' 2>/dev/null | head -30 && \
-    echo '=== any large ELF (likely kernel) ===' && \
-    find /tmp/k-5.15 -maxdepth 6 -type f -size +1M 2>/dev/null | head -30 && \
-    echo '=== /data dirs ===' && \
-    find /tmp/k-5.15 -maxdepth 3 -type d 2>/dev/null | head -40 && \
-    false # fail intentionally so we get the logs
+RUN lvh kernels pull 6.6-main 2>&1 | head -60 \
+ && echo '--- pulled tree ---' \
+ && find / -maxdepth 5 -iname '*vmlin*' 2>/dev/null | head -20 \
+ && echo '--- ~/.config/lvh ---' \
+ && find ~/.config -maxdepth 6 -type f 2>/dev/null | head -20 \
+ && false # diagnostic: fail to surface the layout
 
 # ----- Stage B: generate vmlinux.h (from 6.12, newest of the matrix) -
 FROM alpine:3.20 AS btf-dump

--- a/ebpf-core-firecracker-depot/infra/docker/ebpf-runner-lvh.Dockerfile
+++ b/ebpf-core-firecracker-depot/infra/docker/ebpf-runner-lvh.Dockerfile
@@ -4,51 +4,54 @@
 #
 # Replaces the hand-rolled kernel-fetch in ebpf-runner.Dockerfile
 # (apt-install linux-image-virtual + curl+dpkg-deb pinned launchpad
-# debs + extract-vmlinux) with Cilium's little-vm-helper kernel
-# catalog at quay.io/lvh-images/complexity-test:<ver>-<timestamp>.
+# debs + extract-vmlinux) with Cilium's little-vm-helper CLI.
 #
-# Why bother:
-#   - LVH is the canonical "matrix BPF tests across kernel versions
-#     in CI" tooling — Cilium use it in their own production CI.
-#   - The images are pre-built with the BPF subsystems Cilium needs
-#     (BTF, all the verifier knobs, debug info). We don't have to
-#     trust an Ubuntu kernel's config or fish vmlinux out of vmlinuz.
-#   - Bumping to a new kernel == bump one tag string.
+# `lvh kernels pull <tag>` downloads kernel artefacts from
+# quay.io/lvh-images/kernel-images:<tag> and extracts them as
+#   ./<tag>/boot/vmlinux-X.Y.Z   (ELF, ready for Firecracker)
+#   ./<tag>/boot/vmlinuz-X.Y.Z   (compressed bzImage)
+#   ./<tag>/boot/btf-X.Y.Z       (raw BTF data)
+#   plus System.map, config, lib/modules/...
 #
-# Tags pinned to the timestamp Cilium's tests-datapath-verifier.yaml
-# uses on `main`. Renovate-bot rotates them upstream; bump here by
-# copy-pasting whatever cilium/cilium currently uses.
+# IMPORTANT: do NOT confuse `quay.io/lvh-images/kernel-images`
+# (raw kernel files, what we want) with the similar-named
+# `quay.io/lvh-images/complexity-test:<ver>` images (entire qcow2
+# VM disks for lvh's run command — different beast entirely; the
+# qcow2s contain `/data/images/*.qcow2.zst`, not /boot/vmlinux).
 
-# Use lvh CLI to pull kernels — it knows the registry URL convention
-# and handles whatever extraction is needed to surface vmlinuz/vmlinux
-# files. The complexity-test:<ver> images we tried directly are qcow2
-# VM disks, not raw kernel artefacts.
-
-# ----- Stage A: install lvh CLI + pull kernels -----------------------
+# ----- Stage A: build the lvh CLI -----------------------------------
+# Need go >= 1.25.7 for lvh; alpine 3.20 ships 1.22, so pin the image.
 FROM golang:1.25-alpine AS lvh-cli
 RUN apk add --no-cache git make build-base
-RUN go install github.com/cilium/little-vm-helper/cmd/lvh@latest
+RUN go install github.com/cilium/little-vm-helper/cmd/lvh@latest \
+ && /go/bin/lvh --help 2>&1 | head -3
 
+# ----- Stage B: pull kernels via lvh CLI -----------------------------
 FROM alpine:3.20 AS kernel-collect
 
-RUN apk add --no-cache ca-certificates curl file bash
+RUN apk add --no-cache ca-certificates curl file
 
 COPY --from=lvh-cli /go/bin/lvh /usr/local/bin/lvh
 
-# Probe what `lvh kernels pull` actually does with one version, then
-# dump the resulting tree so we know how to wire it for real.
-RUN lvh kernels --help 2>&1 | head -40 \
- && echo '--- pull help ---' \
- && lvh kernels pull --help 2>&1 | head -40
+# Pin to "-main" tags, which the LVH project rebuilds nightly. Bump
+# to a timestamp pin once you've picked a version known to work with
+# your probe (e.g. 6.6-20251015.123456).
+WORKDIR /work
+RUN lvh kernels pull 5.15-main \
+ && lvh kernels pull 6.1-main \
+ && lvh kernels pull 6.6-main \
+ && lvh kernels pull 6.12-main \
+ && ls -la /work/
 
-RUN lvh kernels pull 6.6-main 2>&1 | head -60 \
- && echo '--- pulled tree ---' \
- && find / -maxdepth 5 -iname '*vmlin*' 2>/dev/null | head -20 \
- && echo '--- ~/.config/lvh ---' \
- && find ~/.config -maxdepth 6 -type f 2>/dev/null | head -20 \
- && false # diagnostic: fail to surface the layout
+# Each tag dir has /boot/vmlinux-X.Y.Z and /boot/vmlinuz-X.Y.Z.
+# Take the uncompressed vmlinux ELF (Firecracker boots it directly).
+RUN for v in 5.15 6.1 6.6 6.12; do \
+      cp /work/$v-main/boot/vmlinux-* /work/vmlinux-$v; \
+      file /work/vmlinux-$v; \
+    done \
+ && ls -lh /work/vmlinux-*
 
-# ----- Stage B: generate vmlinux.h (from 6.12, newest of the matrix) -
+# ----- Stage C: generate vmlinux.h from the newest kernel ------------
 FROM alpine:3.20 AS btf-dump
 
 RUN apk add --no-cache bpftool file
@@ -59,7 +62,7 @@ RUN bpftool btf dump file /tmp/vmlinux format c > /tmp/vmlinux.h \
  && wc -l /tmp/vmlinux.h \
  && head -5 /tmp/vmlinux.h
 
-# ----- Stage C: build probe + static-musl loader ---------------------
+# ----- Stage D: build probe + static-musl loader ---------------------
 FROM alpine:3.20 AS build
 
 RUN apk add --no-cache \
@@ -79,7 +82,7 @@ RUN make -j$(nproc) all \
  && file probe.bpf.o loader \
  && ls -lh probe.bpf.o loader
 
-# ----- Stage D: initrd cpio ------------------------------------------
+# ----- Stage E: initrd cpio ------------------------------------------
 FROM alpine:3.20 AS initrd-build
 
 RUN apk add --no-cache cpio
@@ -92,7 +95,7 @@ RUN chmod +x /initrd/init \
  && find . -print0 | cpio -o -H newc --null > /tmp/initrd.cpio \
  && ls -lh /tmp/initrd.cpio
 
-# ----- Stage E: final runtime image ----------------------------------
+# ----- Stage F: final runtime image ----------------------------------
 FROM buildpack-deps:24.04-scm
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/ebpf-core-firecracker-depot/infra/docker/ebpf-runner-lvh.Dockerfile
+++ b/ebpf-core-firecracker-depot/infra/docker/ebpf-runner-lvh.Dockerfile
@@ -37,14 +37,11 @@ RUN sed -i 's|http://archive.ubuntu.com/ubuntu|http://mirror.facebook.net/ubuntu
         ca-certificates curl xz-utils zstd lz4 lzop binutils file \
  && rm -rf /var/lib/apt/lists/*
 
-# LVH images put the bootable kernel at /boot/vmlinuz-X.Y.Z. Some
-# variants also expose a pre-extracted /boot/vmlinux-X.Y.Z. We copy
-# the whole /boot/ dir from each LVH stage and pick the right file
-# in the next RUN.
-COPY --from=lvh-5.15  /boot/ /tmp/k-5.15/
-COPY --from=lvh-6.1   /boot/ /tmp/k-6.1/
-COPY --from=lvh-6.6   /boot/ /tmp/k-6.6/
-COPY --from=lvh-6.12  /boot/ /tmp/k-6.12/
+# Diagnostic: dump the full root of the smallest LVH image so we
+# can find where the bootable kernel actually lives in this image
+# family. (First pass assumed /boot/ which doesn't exist; this
+# unblocks figuring out the real path.)
+COPY --from=lvh-5.15  / /tmp/k-5.15/
 
 # extract-vmlinux is the canonical kernel.org script that strips
 # the bootloader wrapper from a compressed bzImage. It groks gzip,
@@ -52,19 +49,15 @@ COPY --from=lvh-6.12  /boot/ /tmp/k-6.12/
 RUN curl -fsSL https://raw.githubusercontent.com/torvalds/linux/v6.8/scripts/extract-vmlinux -o /usr/local/bin/extract-vmlinux \
  && chmod +x /usr/local/bin/extract-vmlinux
 
-RUN mkdir -p /work && set -e && \
-    for v in 5.15 6.1 6.6 6.12; do \
-      echo "=== LVH kernel $v boot dir ==="; \
-      ls -la /tmp/k-$v/ || true; \
-      vmlinuz="$(ls /tmp/k-$v/vmlinuz-* 2>/dev/null | head -1)"; \
-      if [ -z "$vmlinuz" ]; then \
-        echo "ERROR: no vmlinuz found for $v" >&2; \
-        exit 1; \
-      fi; \
-      extract-vmlinux "$vmlinuz" > /work/vmlinux-$v; \
-      file /work/vmlinux-$v; \
-    done; \
-    ls -lh /work/vmlinux-*
+RUN echo '=== top-level dirs of LVH 5.15 image ===' && \
+    ls -la /tmp/k-5.15/ && \
+    echo '=== any file with "vmlin" in name ===' && \
+    find /tmp/k-5.15 -maxdepth 6 -iname '*vmlin*' 2>/dev/null | head -30 && \
+    echo '=== any large ELF (likely kernel) ===' && \
+    find /tmp/k-5.15 -maxdepth 6 -type f -size +1M 2>/dev/null | head -30 && \
+    echo '=== /data dirs ===' && \
+    find /tmp/k-5.15 -maxdepth 3 -type d 2>/dev/null | head -40 && \
+    false # fail intentionally so we get the logs
 
 # ----- Stage B: generate vmlinux.h (from 6.12, newest of the matrix) -
 FROM alpine:3.20 AS btf-dump

--- a/ebpf-core-firecracker-depot/infra/docker/ebpf-runner-lvh.Dockerfile
+++ b/ebpf-core-firecracker-depot/infra/docker/ebpf-runner-lvh.Dockerfile
@@ -25,7 +25,7 @@
 # VM disks, not raw kernel artefacts.
 
 # ----- Stage A: install lvh CLI + pull kernels -----------------------
-FROM golang:1.23-alpine AS lvh-cli
+FROM golang:1.25-alpine AS lvh-cli
 RUN apk add --no-cache git make build-base
 RUN go install github.com/cilium/little-vm-helper/cmd/lvh@latest
 

--- a/ebpf-core-firecracker-depot/infra/docker/ebpf-runner.Dockerfile
+++ b/ebpf-core-firecracker-depot/infra/docker/ebpf-runner.Dockerfile
@@ -21,19 +21,18 @@ RUN sed -i 's|http://archive.ubuntu.com/ubuntu|http://mirror.facebook.net/ubuntu
         /etc/apt/sources.list /etc/apt/sources.list.d/*.sources 2>/dev/null || true \
  && apt-get update \
  && apt-get install -y --no-install-recommends \
-        ca-certificates curl xz-utils zstd lz4 lzop dpkg binutils file \
+        ca-certificates curl xz-utils zstd lz4 lzop binutils file \
+        linux-image-virtual \
  && rm -rf /var/lib/apt/lists/*
 
 # Ubuntu 24.04 (noble) ships kernel 6.8 with CONFIG_DEBUG_INFO_BTF=y so
 # /sys/kernel/btf/vmlinux exists in the running guest and libbpf can
-# resolve CO-RE relocations.  Pull a specific 6.8.x build for
-# reproducibility.
-ARG KERNEL_DEB_URL=https://launchpad.net/ubuntu/+source/linux/6.8.0-83.83/+build/31195822/+files/linux-image-unsigned-6.8.0-83-generic_6.8.0-83.83_amd64.deb
-RUN mkdir -p /work/deb \
- && curl -fsSL "$KERNEL_DEB_URL" -o /work/kernel.deb \
- && dpkg-deb -x /work/kernel.deb /work/deb \
- && ls -lh /work/deb/boot/vmlinuz* \
- && cp /work/deb/boot/vmlinuz-* /work/vmlinuz
+# resolve CO-RE relocations. `linux-image-virtual` pulls a minimal
+# variant suitable for KVM guests (still BTF-enabled).
+RUN mkdir -p /work \
+ && ls -lh /boot/vmlinuz-* \
+ && cp /boot/vmlinuz-*-generic /work/vmlinuz \
+ && file /work/vmlinuz
 
 # Decompress vmlinuz -> vmlinux ELF using the upstream extract-vmlinux
 # script (works whether the inner image is gzipped, zstd, lz4, lzop).

--- a/ebpf-core-firecracker-depot/infra/docker/ebpf-runner.Dockerfile
+++ b/ebpf-core-firecracker-depot/infra/docker/ebpf-runner.Dockerfile
@@ -60,12 +60,14 @@ FROM alpine:3.20 AS build
 
 # Alpine bundles static .a archives inside the -dev packages
 # (libbpf-dev ships /usr/lib/libbpf.a, elfutils-dev ships libelf.a).
-# Only zlib has a separate -static apk.
+# libelf.a calls into zstd/xz/bz2 for compressed-ELF-section support,
+# so all three need static counterparts too.
 RUN apk add --no-cache \
         build-base clang lld llvm \
         libbpf-dev \
         elfutils-dev \
         zlib-dev zlib-static \
+        zstd-static xz-static bzip2-static \
         linux-headers bpftool \
         argp-standalone
 

--- a/ebpf-core-firecracker-depot/infra/docker/ebpf-runner.Dockerfile
+++ b/ebpf-core-firecracker-depot/infra/docker/ebpf-runner.Dockerfile
@@ -21,33 +21,58 @@ RUN sed -i 's|http://archive.ubuntu.com/ubuntu|http://mirror.facebook.net/ubuntu
         /etc/apt/sources.list /etc/apt/sources.list.d/*.sources 2>/dev/null || true \
  && apt-get update \
  && apt-get install -y --no-install-recommends \
-        ca-certificates curl xz-utils zstd lz4 lzop binutils file \
+        ca-certificates curl xz-utils zstd lz4 lzop binutils file dpkg \
         linux-image-virtual \
  && rm -rf /var/lib/apt/lists/*
 
-# Ubuntu 24.04 (noble) ships kernel 6.8 with CONFIG_DEBUG_INFO_BTF=y so
-# /sys/kernel/btf/vmlinux exists in the running guest and libbpf can
-# resolve CO-RE relocations. `linux-image-virtual` pulls a minimal
-# variant suitable for KVM guests (still BTF-enabled).
-RUN mkdir -p /work \
- && ls -lh /boot/vmlinuz-* \
- && cp /boot/vmlinuz-*-generic /work/vmlinuz \
- && file /work/vmlinuz
+# Three Linux kernels with CONFIG_DEBUG_INFO_BTF=y so /sys/kernel/btf/
+# vmlinux exists in the guest and libbpf can resolve CO-RE relocations
+# at load time:
+#
+#   6.8  — Ubuntu noble's stock kernel (from apt linux-image-virtual)
+#   6.1  — kernel.ubuntu.com mainline build of vanilla v6.1.0
+#   5.15 — kernel.ubuntu.com mainline build of vanilla v5.15.0
+#
+# Three different upstream layouts of struct task_struct => CO-RE
+# field-offset relocations actually have to do work.
+#
+# These mainline URLs are pinned to specific point releases (the
+# date-stamped filename is the artefact ID); they don't move.
 
-# Decompress vmlinuz -> vmlinux ELF using the upstream extract-vmlinux
-# script (works whether the inner image is gzipped, zstd, lz4, lzop).
+ARG KERNEL_6_1_URL=http://kernel.ubuntu.com/mainline/v6.1/amd64/linux-image-unsigned-6.1.0-060100-generic_6.1.0-060100.202303090726_amd64.deb
+ARG KERNEL_5_15_URL=http://kernel.ubuntu.com/mainline/v5.15/amd64/linux-image-unsigned-5.15.0-051500-generic_5.15.0-051500.202110312130_amd64.deb
+
+RUN mkdir -p /work \
+ && cp /boot/vmlinuz-*-generic /work/vmlinuz-6.8 \
+ && curl -fsSL "$KERNEL_6_1_URL"  -o /work/k61.deb \
+ && curl -fsSL "$KERNEL_5_15_URL" -o /work/k515.deb \
+ && dpkg-deb -x /work/k61.deb  /work/k61 \
+ && dpkg-deb -x /work/k515.deb /work/k515 \
+ && cp /work/k61/boot/vmlinuz-*-generic  /work/vmlinuz-6.1 \
+ && cp /work/k515/boot/vmlinuz-*-generic /work/vmlinuz-5.15 \
+ && rm -rf /work/k61 /work/k515 /work/*.deb \
+ && ls -lh /work/vmlinuz-*
+
+# Decompress each vmlinuz -> vmlinux ELF. extract-vmlinux handles
+# gzip / zstd / lz4 / lzop / xz wrappers.
 RUN curl -fsSL https://raw.githubusercontent.com/torvalds/linux/v6.8/scripts/extract-vmlinux -o /usr/local/bin/extract-vmlinux \
  && chmod +x /usr/local/bin/extract-vmlinux \
- && extract-vmlinux /work/vmlinuz > /work/vmlinux \
- && file /work/vmlinux \
- && ls -lh /work/vmlinux
+ && for v in 5.15 6.1 6.8; do \
+      extract-vmlinux /work/vmlinuz-$v > /work/vmlinux-$v; \
+      file /work/vmlinux-$v; \
+    done \
+ && ls -lh /work/vmlinux-*
 
 # ----- Stage B: generate vmlinux.h from the kernel's BTF --------------
 FROM alpine:3.20 AS btf-dump
 
 RUN apk add --no-cache bpftool file
 
-COPY --from=kernel-fetch /work/vmlinux /tmp/vmlinux
+# Generate vmlinux.h from the NEWEST kernel (6.8). That's the BTF
+# headers the probe will be compiled against. CO-RE relocations at
+# load time will rewrite field offsets when the probe runs against
+# the older 6.1 / 5.15 guest kernels.
+COPY --from=kernel-fetch /work/vmlinux-6.8 /tmp/vmlinux
 
 # bpftool reads BTF straight from the ELF .BTF section. If the kernel
 # was built without CONFIG_DEBUG_INFO_BTF this will fail loudly.
@@ -120,12 +145,19 @@ RUN curl -fsSL "https://github.com/firecracker-microvm/firecracker/releases/down
  && rm -rf /tmp/fc.tgz "/tmp/release-${FIRECRACKER_VERSION}-x86_64" \
  && firecracker --version
 
-COPY --from=kernel-fetch /work/vmlinux       /opt/guest/vmlinux
+# Stage 1 expects /opt/guest/vmlinux (the 6.8 default).
+# Stage 2 picks one of the per-version files under /opt/guest/.
+COPY --from=kernel-fetch /work/vmlinux-5.15  /opt/guest/vmlinux-5.15
+COPY --from=kernel-fetch /work/vmlinux-6.1   /opt/guest/vmlinux-6.1
+COPY --from=kernel-fetch /work/vmlinux-6.8   /opt/guest/vmlinux-6.8
 COPY --from=initrd-build /tmp/initrd.cpio    /opt/guest/initrd.cpio
 COPY scripts/run_linux_guest.sh              /opt/run_linux_guest.sh
 
-RUN chmod +x /opt/run_linux_guest.sh \
- && file /opt/guest/vmlinux \
- && ls -lh /opt/guest/vmlinux /opt/guest/initrd.cpio /opt/run_linux_guest.sh
+# /opt/guest/vmlinux is a symlink to 6.8 so the Stage 1 workflow that
+# hardcoded the path keeps working.
+RUN ln -s vmlinux-6.8 /opt/guest/vmlinux \
+ && chmod +x /opt/run_linux_guest.sh \
+ && for v in 5.15 6.1 6.8; do file /opt/guest/vmlinux-$v; done \
+ && ls -lh /opt/guest/ /opt/run_linux_guest.sh
 
 WORKDIR /opt

--- a/ebpf-core-firecracker-depot/infra/docker/ebpf-runner.Dockerfile
+++ b/ebpf-core-firecracker-depot/infra/docker/ebpf-runner.Dockerfile
@@ -59,12 +59,16 @@ RUN bpftool btf dump file /tmp/vmlinux format c > /tmp/vmlinux.h \
 # ----- Stage C: cross-compile probe + loader --------------------------
 FROM alpine:3.20 AS build
 
+# Alpine bundles static .a archives inside the -dev packages
+# (libbpf-dev ships /usr/lib/libbpf.a, elfutils-dev ships libelf.a).
+# Only zlib has a separate -static apk.
 RUN apk add --no-cache \
         build-base clang lld llvm \
-        libbpf-dev libbpf-static \
-        elfutils-dev elfutils-static \
+        libbpf-dev \
+        elfutils-dev \
         zlib-dev zlib-static \
-        linux-headers bpftool
+        linux-headers bpftool \
+        argp-standalone
 
 WORKDIR /src
 COPY src/ .

--- a/ebpf-core-firecracker-depot/infra/docker/ebpf-runner.Dockerfile
+++ b/ebpf-core-firecracker-depot/infra/docker/ebpf-runner.Dockerfile
@@ -1,0 +1,126 @@
+# syntax=docker/dockerfile:1.7
+#
+# Cached runner image for the CO-RE eBPF experiment.
+#
+# Stages:
+#   A  fetch + decompress a Linux kernel ELF with BTF
+#   B  generate vmlinux.h from that kernel's BTF
+#   C  cross-compile probe.bpf.o + static-musl loader against vmlinux.h
+#   D  assemble the initrd cpio (init = loader, /probe.bpf.o)
+#   E  final runtime image: firecracker + util-linux + (kernel, initrd, run script)
+#
+# Built via .depot/workflows/build-runner-image.yml and consumed by
+# .depot/workflows/boot-single-kernel.yml.
+
+# ----- Stage A: fetch a Linux kernel with BTF -------------------------
+FROM ubuntu:24.04 AS kernel-fetch
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN sed -i 's|http://archive.ubuntu.com/ubuntu|http://mirror.facebook.net/ubuntu|g; s|http://security.ubuntu.com/ubuntu|http://mirror.facebook.net/ubuntu|g' \
+        /etc/apt/sources.list /etc/apt/sources.list.d/*.sources 2>/dev/null || true \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends \
+        ca-certificates curl xz-utils zstd lz4 lzop dpkg binutils file \
+ && rm -rf /var/lib/apt/lists/*
+
+# Ubuntu 24.04 (noble) ships kernel 6.8 with CONFIG_DEBUG_INFO_BTF=y so
+# /sys/kernel/btf/vmlinux exists in the running guest and libbpf can
+# resolve CO-RE relocations.  Pull a specific 6.8.x build for
+# reproducibility.
+ARG KERNEL_DEB_URL=https://launchpad.net/ubuntu/+source/linux/6.8.0-83.83/+build/31195822/+files/linux-image-unsigned-6.8.0-83-generic_6.8.0-83.83_amd64.deb
+RUN mkdir -p /work/deb \
+ && curl -fsSL "$KERNEL_DEB_URL" -o /work/kernel.deb \
+ && dpkg-deb -x /work/kernel.deb /work/deb \
+ && ls -lh /work/deb/boot/vmlinuz* \
+ && cp /work/deb/boot/vmlinuz-* /work/vmlinuz
+
+# Decompress vmlinuz -> vmlinux ELF using the upstream extract-vmlinux
+# script (works whether the inner image is gzipped, zstd, lz4, lzop).
+RUN curl -fsSL https://raw.githubusercontent.com/torvalds/linux/v6.8/scripts/extract-vmlinux -o /usr/local/bin/extract-vmlinux \
+ && chmod +x /usr/local/bin/extract-vmlinux \
+ && extract-vmlinux /work/vmlinuz > /work/vmlinux \
+ && file /work/vmlinux \
+ && ls -lh /work/vmlinux
+
+# ----- Stage B: generate vmlinux.h from the kernel's BTF --------------
+FROM alpine:3.20 AS btf-dump
+
+RUN apk add --no-cache bpftool file
+
+COPY --from=kernel-fetch /work/vmlinux /tmp/vmlinux
+
+# bpftool reads BTF straight from the ELF .BTF section. If the kernel
+# was built without CONFIG_DEBUG_INFO_BTF this will fail loudly.
+RUN bpftool btf dump file /tmp/vmlinux format c > /tmp/vmlinux.h \
+ && wc -l /tmp/vmlinux.h \
+ && head -5 /tmp/vmlinux.h
+
+# ----- Stage C: cross-compile probe + loader --------------------------
+FROM alpine:3.20 AS build
+
+RUN apk add --no-cache \
+        build-base clang lld llvm \
+        libbpf-dev libbpf-static \
+        elfutils-dev elfutils-static \
+        zlib-dev zlib-static \
+        linux-headers bpftool
+
+WORKDIR /src
+COPY src/ .
+COPY --from=btf-dump /tmp/vmlinux.h ./vmlinux.h
+
+RUN make -j$(nproc) all \
+ && file probe.bpf.o loader \
+ && ls -lh probe.bpf.o loader \
+ && echo '--- loader is statically linked ---' \
+ && (ldd loader 2>&1 || true) | head -5
+
+# ----- Stage D: assemble initrd cpio ----------------------------------
+FROM alpine:3.20 AS initrd-build
+
+RUN apk add --no-cache cpio
+
+COPY --from=build /src/loader      /initrd/init
+COPY --from=build /src/probe.bpf.o /initrd/probe.bpf.o
+
+# Linux's initrd handler invokes /init (the binary at the cpio root).
+# We chmod +x defensively even though the build stage already strips
+# and marks executable.
+RUN chmod +x /initrd/init \
+ && cd /initrd \
+ && find . -print0 | cpio -o -H newc --null > /tmp/initrd.cpio \
+ && ls -lh /tmp/initrd.cpio \
+ && echo '--- initrd contents ---' \
+ && cpio -tv < /tmp/initrd.cpio
+
+# ----- Stage E: final runtime image -----------------------------------
+FROM buildpack-deps:24.04-scm
+
+ENV DEBIAN_FRONTEND=noninteractive
+ARG FIRECRACKER_VERSION=v1.15.0
+
+# Same defensive apt-mirror swap as the sibling unikraft experiment.
+RUN sed -i 's|http://archive.ubuntu.com/ubuntu|http://mirror.facebook.net/ubuntu|g; s|http://security.ubuntu.com/ubuntu|http://mirror.facebook.net/ubuntu|g' \
+        /etc/apt/sources.list /etc/apt/sources.list.d/*.sources 2>/dev/null || true \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends \
+        ca-certificates curl jq xz-utils tar gzip uuid-runtime file \
+        util-linux bsdmainutils \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL "https://github.com/firecracker-microvm/firecracker/releases/download/${FIRECRACKER_VERSION}/firecracker-${FIRECRACKER_VERSION}-x86_64.tgz" -o /tmp/fc.tgz \
+ && tar -xzf /tmp/fc.tgz -C /tmp \
+ && install -m 0755 "/tmp/release-${FIRECRACKER_VERSION}-x86_64/firecracker-${FIRECRACKER_VERSION}-x86_64" /usr/local/bin/firecracker \
+ && rm -rf /tmp/fc.tgz "/tmp/release-${FIRECRACKER_VERSION}-x86_64" \
+ && firecracker --version
+
+COPY --from=kernel-fetch /work/vmlinux       /opt/guest/vmlinux
+COPY --from=initrd-build /tmp/initrd.cpio    /opt/guest/initrd.cpio
+COPY scripts/run_linux_guest.sh              /opt/run_linux_guest.sh
+
+RUN chmod +x /opt/run_linux_guest.sh \
+ && file /opt/guest/vmlinux \
+ && ls -lh /opt/guest/vmlinux /opt/guest/initrd.cpio /opt/run_linux_guest.sh
+
+WORKDIR /opt

--- a/ebpf-core-firecracker-depot/scripts/run_linux_guest.sh
+++ b/ebpf-core-firecracker-depot/scripts/run_linux_guest.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Boot a Linux kernel + initrd under Firecracker via its REST API.
+# Adapted from PR #18's run_unikernel.sh (Unikraft); same PTY trick
+# for guest serial, same FC --log-path split. Differences:
+#   - Linux-style boot_args (console=ttyS0 reboot=k panic=1)
+#   - initrd_path is required, not optional
+#   - mem_size_mib defaults to 512 (libbpf + maps + ringbuf)
+#
+# Usage: run_linux_guest.sh <kernel> <initrd> [grep-pattern]
+#   grep-pattern defaults to "BPF_RESULT_END" (loader emits it)
+#   WAIT_ITERS env var controls poll timeout in 0.1s units (default 600 == 60s)
+
+set -euo pipefail
+
+kernel="${1:?missing kernel path}"
+initrd="${2:?missing initrd path}"
+pattern="${3:-BPF_RESULT_END}"
+wait_iters="${WAIT_ITERS:-600}"
+boot_args="${BOOT_ARGS:-console=ttyS0 reboot=k panic=1 root=/dev/ram0 rw}"
+mem_mib="${MEM_MIB:-512}"
+
+for f in "$kernel" "$initrd"; do
+  if [[ ! -f "$f" ]]; then
+    echo "ERROR: required file not found: $f" >&2
+    exit 2
+  fi
+done
+
+sock="$(mktemp -u /tmp/fc-XXXXXX.sock)"
+serial_log="$(mktemp -t fc-serial-XXXXXX)"
+fc_log="$(mktemp -t fc-internal-XXXXXX)"
+: > "$serial_log"
+: > "$fc_log"
+
+cleanup() {
+  for pid in "${fc_pid:-}" "${script_pid:-}"; do
+    if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+      kill "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+    fi
+  done
+  rm -f "$sock"
+}
+trap cleanup EXIT
+
+# Wrap firecracker under `script` so it gets a PTY — guest serial is
+# dropped otherwise (firecracker-microvm/firecracker#2729).
+script -qfec "firecracker --api-sock '$sock' --log-path '$fc_log' --level Info" \
+  "$serial_log" </dev/null >/dev/null 2>&1 &
+script_pid=$!
+
+for _ in $(seq 1 50); do
+  fc_pid="$(pgrep -P "$script_pid" firecracker 2>/dev/null | head -1 || true)"
+  [[ -n "$fc_pid" ]] && break
+  sleep 0.1
+done
+
+for _ in $(seq 1 50); do
+  [[ -S "$sock" ]] && break
+  sleep 0.1
+done
+if [[ ! -S "$sock" ]]; then
+  echo "ERROR: firecracker did not create $sock" >&2
+  cat "$fc_log" >&2 || true
+  exit 3
+fi
+
+curl -fsS --unix-socket "$sock" -X PUT 'http://localhost/machine-config' \
+  -H 'Content-Type: application/json' \
+  -d "$(jq -nc --argjson m "$mem_mib" '{vcpu_count:1, mem_size_mib:$m, smt:false}')"
+
+curl -fsS --unix-socket "$sock" -X PUT 'http://localhost/boot-source' \
+  -H 'Content-Type: application/json' \
+  -d "$(jq -nc --arg k "$kernel" --arg i "$initrd" --arg b "$boot_args" \
+        '{kernel_image_path:$k, initrd_path:$i, boot_args:$b}')"
+
+t0=$(date +%s%N)
+curl -fsS --unix-socket "$sock" -X PUT 'http://localhost/actions' \
+  -H 'Content-Type: application/json' \
+  -d '{"action_type":"InstanceStart"}'
+
+for _ in $(seq 1 "$wait_iters"); do
+  if grep -qF "$pattern" "$serial_log" 2>/dev/null; then
+    break
+  fi
+  sleep 0.1
+done
+t1=$(date +%s%N)
+
+echo "--- guest serial ---"
+cat "$serial_log" 2>/dev/null || true
+echo "--- firecracker internal log (tail) ---"
+tail -30 "$fc_log" 2>/dev/null || true
+echo "---"
+echo "elapsed_ms=$(( (t1 - t0) / 1000000 ))"
+echo "serial_log_bytes=$(stat -c%s "$serial_log" 2>/dev/null || echo 0)"
+
+# Extract the JSON between BPF_RESULT_BEGIN/END markers (strip CR from PTY).
+json="$(awk '/BPF_RESULT_BEGIN/{p=1; next} /BPF_RESULT_END/{p=0} p' "$serial_log" | tr -d '\r')"
+
+if [[ -z "$json" ]]; then
+  echo "ERROR: no BPF_RESULT markers in serial output" >&2
+  exit 1
+fi
+
+echo "=== bpf result ==="
+echo "$json" | jq . 2>/dev/null || echo "$json"
+
+verdict="$(echo "$json" | jq -r '.verdict' 2>/dev/null || echo unknown)"
+case "$verdict" in
+  OK)   echo "VERDICT: OK";   exit 0 ;;
+  FAIL) echo "VERDICT: FAIL"; exit 1 ;;
+  *)    echo "VERDICT: unknown ($verdict)"; exit 2 ;;
+esac

--- a/ebpf-core-firecracker-depot/src/Makefile
+++ b/ebpf-core-firecracker-depot/src/Makefile
@@ -1,0 +1,43 @@
+# Build the BPF probe (probe.bpf.o) and the static-musl loader binary.
+# Invoked inside infra/docker/ebpf-runner.Dockerfile's Alpine builder
+# stage where clang, libbpf-static, libelf-static and zlib-static are
+# all available.
+#
+# Inputs:
+#   VMLINUX_H   path to a pre-generated vmlinux.h (from `bpftool btf
+#               dump file <vmlinux> format c`). Defaults to ./vmlinux.h
+#               which the Dockerfile generates before invoking make.
+#
+# Outputs:
+#   probe.bpf.o   CO-RE eBPF object, loaded by the userspace loader
+#   loader        static-musl ELF, runs as PID 1 inside the guest
+
+VMLINUX_H ?= vmlinux.h
+
+CLANG     ?= clang
+CC        ?= gcc
+
+# clang for BPF — -g keeps DWARF/BTF so libbpf can do CO-RE relocs.
+BPF_CFLAGS = -O2 -g -Wall -Werror \
+             -target bpf \
+             -D__TARGET_ARCH_x86 \
+             -I.
+
+# Static-musl userspace. -lbpf needs -lelf -lz transitively.
+LOADER_CFLAGS = -O2 -Wall -Wextra
+LOADER_LDLIBS = -lbpf -lelf -lz
+LOADER_LDFLAGS = -static -no-pie
+
+.PHONY: all clean
+
+all: probe.bpf.o loader
+
+probe.bpf.o: probe.bpf.c $(VMLINUX_H)
+	$(CLANG) $(BPF_CFLAGS) -c $< -o $@
+
+loader: loader.c
+	$(CC) $(LOADER_CFLAGS) $(LOADER_LDFLAGS) $< $(LOADER_LDLIBS) -o $@
+	strip --strip-all $@
+
+clean:
+	rm -f probe.bpf.o loader

--- a/ebpf-core-firecracker-depot/src/Makefile
+++ b/ebpf-core-firecracker-depot/src/Makefile
@@ -23,9 +23,10 @@ BPF_CFLAGS = -O2 -g -Wall -Werror \
              -D__TARGET_ARCH_x86 \
              -I.
 
-# Static-musl userspace. -lbpf needs -lelf -lz transitively.
+# Static-musl userspace. -lbpf needs -lelf -lz transitively, and
+# libelf.a needs -lzstd -llzma -lbz2 for ELF compressed-section support.
 LOADER_CFLAGS = -O2 -Wall -Wextra
-LOADER_LDLIBS = -lbpf -lelf -lz
+LOADER_LDLIBS = -lbpf -lelf -lz -lzstd -llzma -lbz2
 LOADER_LDFLAGS = -static -no-pie
 
 .PHONY: all clean

--- a/ebpf-core-firecracker-depot/src/loader.c
+++ b/ebpf-core-firecracker-depot/src/loader.c
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: GPL-2.0
+//
+// Userspace loader running as PID 1 inside a Firecracker guest. Loads
+// /probe.bpf.o via libbpf (this is where CO-RE relocations resolve
+// against the kernel's BTF), attaches it to sys_enter_execve, fires
+// an execve to trigger the probe, captures one event off the ringbuf,
+// prints a JSON verdict between BPF_RESULT_BEGIN/END markers, and
+// reboots so Firecracker exits cleanly.
+//
+// Built static-musl + libbpf-static so the initrd has zero shared-lib
+// dependencies. See infra/docker/ebpf-runner.Dockerfile.
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mount.h>
+#include <sys/reboot.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <linux/reboot.h>
+
+#include <bpf/libbpf.h>
+
+// Must match struct probe_event in probe.bpf.c
+struct probe_event {
+	uint32_t pid;
+	uint32_t ppid;
+	char     comm[16];
+};
+
+static int event_count;
+static struct probe_event last_event;
+
+static int handle_event(void *ctx, void *data, size_t data_sz)
+{
+	(void)ctx;
+	if (data_sz < sizeof(struct probe_event))
+		return 0;
+	memcpy(&last_event, data, sizeof(last_event));
+	event_count++;
+	return 0;
+}
+
+static int libbpf_log(enum libbpf_print_level level, const char *fmt, va_list args)
+{
+	// keep WARN/ERROR on stderr; suppress INFO to keep serial clean
+	if (level == LIBBPF_DEBUG || level == LIBBPF_INFO)
+		return 0;
+	return vfprintf(stderr, fmt, args);
+}
+
+// Get a monotonic millisecond timestamp.
+static long long now_ms(void)
+{
+	struct timespec ts;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return (long long)ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+}
+
+// Print a JSON line wrapped in the BEGIN/END markers expected by the
+// host-side parser, then halt.
+__attribute__((noreturn))
+static void emit_and_halt(const char *json)
+{
+	printf("BPF_RESULT_BEGIN\n");
+	printf("%s\n", json);
+	printf("BPF_RESULT_END\n");
+	fflush(stdout);
+	sync();
+	// Give the serial console a moment to drain through Firecracker's
+	// UART emulator before we yank power.
+	sleep(1);
+	reboot(LINUX_REBOOT_CMD_RESTART);
+	for (;;) pause();
+}
+
+int main(int argc, char **argv)
+{
+	long long t0 = now_ms();
+
+	// As PID 1 we have to mount our own /proc, /sys, /sys/fs/bpf.
+	// Ignore failures (the bpf filesystem might already be mounted by
+	// the kernel, /proc might be required for libbpf, etc).
+	mkdir("/proc", 0755);
+	mkdir("/sys", 0755);
+	mount("proc",  "/proc", "proc",  0, NULL);
+	mount("sysfs", "/sys",  "sysfs", 0, NULL);
+	mkdir("/sys/fs/bpf", 0755);
+	mount("bpf",   "/sys/fs/bpf", "bpf", 0, NULL);
+	// tracefs is required so libbpf can attach to tracepoints by path
+	mkdir("/sys/kernel/tracing", 0755);
+	mount("tracefs", "/sys/kernel/tracing", "tracefs", 0, NULL);
+
+	libbpf_set_print(libbpf_log);
+
+	char errbuf[256];
+	const char *json_fmt;
+	(void)json_fmt;
+
+	struct bpf_object *obj = bpf_object__open_file("/probe.bpf.o", NULL);
+	long err = libbpf_get_error(obj);
+	if (!obj || err) {
+		snprintf(errbuf, sizeof(errbuf),
+			 "{\"verdict\":\"FAIL\",\"stage\":\"open\",\"err\":%ld,\"errno\":%d}",
+			 err, errno);
+		emit_and_halt(errbuf);
+	}
+
+	if (bpf_object__load(obj)) {
+		snprintf(errbuf, sizeof(errbuf),
+			 "{\"verdict\":\"FAIL\",\"stage\":\"load\",\"errno\":%d,"
+			 "\"note\":\"CO-RE relocation likely failed; check libbpf stderr\"}",
+			 errno);
+		emit_and_halt(errbuf);
+	}
+
+	struct bpf_program *prog = bpf_object__next_program(obj, NULL);
+	if (!prog) {
+		emit_and_halt("{\"verdict\":\"FAIL\",\"stage\":\"find_prog\"}");
+	}
+
+	struct bpf_link *link = bpf_program__attach(prog);
+	if (!link || libbpf_get_error(link)) {
+		snprintf(errbuf, sizeof(errbuf),
+			 "{\"verdict\":\"FAIL\",\"stage\":\"attach\",\"errno\":%d}", errno);
+		emit_and_halt(errbuf);
+	}
+
+	struct bpf_map *map = bpf_object__find_map_by_name(obj, "events");
+	if (!map) {
+		emit_and_halt("{\"verdict\":\"FAIL\",\"stage\":\"find_map\"}");
+	}
+
+	struct ring_buffer *rb = ring_buffer__new(bpf_map__fd(map), handle_event, NULL, NULL);
+	if (!rb || libbpf_get_error(rb)) {
+		emit_and_halt("{\"verdict\":\"FAIL\",\"stage\":\"ringbuf_new\"}");
+	}
+
+	long long t_loaded = now_ms();
+
+	// Trigger sys_enter_execve from a child so we don't replace ourselves.
+	// We intentionally exec a path that doesn't exist — the tracepoint
+	// fires on syscall ENTRY, before the lookup that would fail with
+	// -ENOENT, so the probe still observes the event.
+	pid_t pid = fork();
+	if (pid == 0) {
+		char *args[] = { (char *)"trigger", NULL };
+		execve("/nonexistent-trigger-path", args, NULL);
+		_exit(0);
+	}
+	int status;
+	if (pid > 0)
+		waitpid(pid, &status, 0);
+
+	// Poll the ringbuf up to ~5s for our event.
+	long long deadline = t_loaded + 5000;
+	while (event_count == 0 && now_ms() < deadline) {
+		ring_buffer__poll(rb, 100);
+	}
+
+	long long t_event = now_ms();
+
+	char json[512];
+	if (event_count > 0) {
+		// Sanitize comm for JSON (cap at NUL, no control chars).
+		char comm[17];
+		memcpy(comm, last_event.comm, 16);
+		comm[16] = '\0';
+		for (int i = 0; comm[i]; i++)
+			if (comm[i] < 0x20 || comm[i] > 0x7e) comm[i] = '?';
+
+		snprintf(json, sizeof(json),
+			 "{\"verdict\":\"OK\","
+			 "\"events\":%d,"
+			 "\"pid\":%u,"
+			 "\"ppid\":%u,"
+			 "\"comm\":\"%s\","
+			 "\"core_relocs\":\"resolved\","
+			 "\"boot_to_load_ms\":%lld,"
+			 "\"load_to_event_ms\":%lld}",
+			 event_count, last_event.pid, last_event.ppid, comm,
+			 t_loaded - t0, t_event - t_loaded);
+	} else {
+		snprintf(json, sizeof(json),
+			 "{\"verdict\":\"FAIL\","
+			 "\"stage\":\"no_events\","
+			 "\"timeout_ms\":5000,"
+			 "\"boot_to_load_ms\":%lld}",
+			 t_loaded - t0);
+	}
+
+	emit_and_halt(json);
+	return 0;
+}

--- a/ebpf-core-firecracker-depot/src/probe.bpf.c
+++ b/ebpf-core-firecracker-depot/src/probe.bpf.c
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0
+//
+// CO-RE eBPF probe for the depot-ci nested-virt experiment.
+//
+// Attaches to the sys_enter_execve tracepoint, reads two
+// CO-RE-relocatable fields from struct task_struct (pid +
+// real_parent->pid + comm[]), and emits one record per event onto a
+// ringbuf. The ringbuf is drained by the userspace loader (loader.c)
+// running as PID 1 inside the FC guest.
+//
+// Reading task_struct fields by name (BPF_CORE_READ) is what makes
+// this a real CO-RE test — libbpf rewrites the field offsets at load
+// time using the kernel's own BTF. A probe that only used helpers
+// like bpf_get_current_pid_tgid() would pass on any kernel without
+// proving CO-RE worked.
+
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_tracing.h>
+
+char LICENSE[] SEC("license") = "GPL";
+
+struct probe_event {
+	__u32 pid;
+	__u32 ppid;
+	char  comm[16];
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_RINGBUF);
+	__uint(max_entries, 1 << 14);  // 16 KiB ringbuf
+} events SEC(".maps");
+
+SEC("tp/syscalls/sys_enter_execve")
+int handle_execve(void *ctx)
+{
+	struct task_struct *t = (struct task_struct *)bpf_get_current_task();
+
+	struct probe_event *e = bpf_ringbuf_reserve(&events, sizeof(*e), 0);
+	if (!e)
+		return 0;
+
+	e->pid  = BPF_CORE_READ(t, pid);
+	e->ppid = BPF_CORE_READ(t, real_parent, pid);
+	BPF_CORE_READ_STR_INTO(&e->comm, t, comm);
+
+	bpf_ringbuf_submit(e, 0);
+	return 0;
+}


### PR DESCRIPTION
Load a CO-RE eBPF probe inside real Linux microVMs under Firecracker on a Depot nested-virt CI runner, and matrix-test the same compiled `.bpf.o` against several guest kernel ABIs.

## What this PR is — and what it isn't

The technical pattern (FC microVMs + matrix BPF testing) **is not new**. Cilium's [little-vm-helper](https://github.com/cilium/little-vm-helper) (LVH) does exactly this and is what real projects reach for. The Linux kernel community uses similar tooling (`virtme-ng`, in-tree selftests). What's incrementally new here is doing it inside a **managed CI service** without self-hosting bare metal or `*.metal`-class instances — a CI delivery-model change, not a kernel/BPF capability one.

This branch ships **both paths** so the comparison is in-tree:

| Path | Kernel source | Kernels | Lines of Dockerfile for kernel fetch | Result |
|---|---|---|---|---|
| Hand-rolled | `apt-install linux-image-virtual` + pinned `kernel.ubuntu.com/mainline` debs + `extract-vmlinux` | 5.15, 6.1, 6.8 | ~50 | **3/3 OK**, run `1tvpz1140t` |
| **LVH-backed** (recommended) | `lvh kernels pull <ver>-main` from `quay.io/lvh-images/kernel-images` | 5.15, 6.1, 6.6, 6.12 | **~10** | **4/4 OK**, run `29mdrxss2z` |

Same `probe.bpf.o`, same loader, same initrd — only the kernel-fetch differs. The hand-rolled variant is in-tree to make the mechanics LVH hides (vmlinuz decompression, BTF dump, cpio init, FC REST + PTY) visible; pick the LVH variant for real work.

## Quickstart

```bash
curl -L https://depot.dev/install-cli.sh | sh
export PATH=$HOME/.depot/bin:$PATH
export DEPOT_TOKEN='depot_org_...'

cd ebpf-core-firecracker-depot

# Hand-rolled flavor (Ubuntu apt + extract-vmlinux):
./experiment.sh build       # ~90 s first time, ~30 s cached
./experiment.sh boot        # ~15 s — Linux 6.8 guest, single boot
./experiment.sh matrix      # ~45 s — 5.15 + 6.1 + 6.8

# LVH-backed flavor (lvh kernels pull):
./experiment.sh build-lvh   # ~90 s first time
./experiment.sh matrix-lvh  # ~45 s — 5.15 + 6.1 + 6.6 + 6.12

./experiment.sh --help
```

## Stage 1 result

```
BPF_RESULT_BEGIN
{"verdict":"OK","events":1,"pid":75,"ppid":1,"comm":"init",
 "core_relocs":"resolved","boot_to_load_ms":14,"load_to_event_ms":0}
BPF_RESULT_END
Firecracker exiting successfully. exit_code=0
```

Run: `5c0tt3hs9s`. Probe attached to `tp/syscalls/sys_enter_execve` and read `task_struct.{pid, real_parent.pid, comm}` via `BPF_CORE_READ`. libbpf resolved every field access against the guest's BTF at load time. PID 1 is the loader; PID 75 is the forked child whose `execve()` triggered the probe.

## Stage 2 — hand-rolled

```
KERNEL     STATUS    BOOT_TO_LOAD    EVENTS
5.15       OK        43ms            1
6.1        OK        12ms            1
6.8        OK        13ms            1
OVERALL: all kernels accepted the probe
```

Run: `1tvpz1140t`. Probe compiled against 6.8's BTF; libbpf relocated it against 5.15 and 6.1 BTFs at load time. Same compiled `.bpf.o`.

## Stage 2 — LVH-backed (recommended)

```
KERNEL     STATUS    BOOT_TO_LOAD    EVENTS
5.15       OK        41ms            1
6.1        OK        13ms            1
6.6        OK        19ms            1
6.12       OK        16ms            1
OVERALL: all LVH kernels accepted the probe
```

Run: `29mdrxss2z`. Same probe + loader + initrd as hand-rolled; only the kernel ELFs differ — pulled by `lvh kernels pull <ver>-main` from `quay.io/lvh-images/kernel-images`. Gains 6.6 and 6.12 versus the hand-rolled set.

## What's in the PR

- `src/probe.bpf.c` — CO-RE probe on `tp/syscalls/sys_enter_execve`, reads `task_struct` fields via `BPF_CORE_READ`.
- `src/loader.c` — static-musl userspace, runs as PID 1, mounts `/proc`/`/sys`/`bpf`/tracefs, opens + loads + attaches the probe, fires a fork+execve to trigger the tracepoint, polls the ringbuf, emits JSON between `BPF_RESULT_BEGIN`/`END` markers, reboots.
- `infra/docker/ebpf-runner.Dockerfile` — hand-rolled 5-stage Dockerfile: apt-install linux-image-virtual + curl pinned mainline debs + `extract-vmlinux` + `bpftool btf dump` + cross-compile probe + loader + cpio + bake into runtime image with firecracker.
- `infra/docker/ebpf-runner-lvh.Dockerfile` — LVH-backed equivalent. Stage A builds the `lvh` CLI; stage B does `lvh kernels pull <ver>-main` for each kernel; rest is identical to the hand-rolled.
- `scripts/run_linux_guest.sh` — FC REST API driver, Linux-style `boot_args`, `initrd_path`, same PTY + `--log-path` split as PR #18.
- `.depot/workflows/{build-runner-image, boot-single-kernel, matrix-kernels, build-runner-lvh-image, matrix-kernels-lvh}.yml` — `defaults.run.shell: bash` on all of them.
- `experiment.sh` — `build` / `boot` / `matrix` for hand-rolled, `build-lvh` / `matrix-lvh` for LVH.

## Gotchas worth flagging (verified)

1. **LVH ships two OCI image families with confusingly similar names.**
   - `quay.io/lvh-images/complexity-test:<ver>-<timestamp>` is a **whole-VM qcow2 disk image** for use with `lvh run`. The container filesystem contains `/data/images/complexity-test_<ver>.qcow2.zst` — no `/boot/vmlinux` directly. Don't try `COPY --from=<that-image> /boot/...` because there's no `/boot/`.
   - `quay.io/lvh-images/kernel-images:<ver>-main` is what `lvh kernels pull` defaults to. The OCI image extracts as `./<tag>/boot/vmlinux-X.Y.Z` (raw ELF, ready for Firecracker). **This is the one you want for FC integration.**
2. **`lvh` needs Go ≥ 1.25.7** to install via `go install`. Use `golang:1.25-alpine` or later as the build stage base.
3. **Static linking libbpf on Alpine**: `libbpf-dev` + `elfutils-dev` bundle their `.a` archives (no separate `-static` apk). libelf transitively calls into zstd/xz/bz2 — add `zlib-static zstd-static xz-static bzip2-static`.
4. **Don't hardcode launchpad URLs** for kernel debs — they 404 as versions roll over. `apt-get install linux-image-virtual` and read whatever `/boot/vmlinuz-*-generic` lands.
5. Same FC-on-CI plumbing as PR #18 (PTY for guest serial via `script -qfec`, `--log-path` to separate FC's slog, `x-token` Depot Registry auth).

## Verification runs

| Workflow | Run | Result |
|---|---|---|
| `build-runner-image` | `vbzq2zn7pw` | hand-rolled image saved, 3 kernels + initrd + probe + loader |
| `boot-single-kernel` | `5c0tt3hs9s` | `verdict:OK`, 14 ms boot-to-load |
| `matrix-kernels` | `1tvpz1140t` | 3/3 OK |
| `build-runner-lvh-image` | `fcgb2krhkg` | LVH image saved, 4 kernels via `lvh kernels pull` |
| `matrix-kernels-lvh` | `29mdrxss2z` | **4/4 OK** |